### PR TITLE
removing delivery strategy field from RecordMetadata

### DIFF
--- a/core/src/main/scala/hydra/core/transport/RecordMetadata.scala
+++ b/core/src/main/scala/hydra/core/transport/RecordMetadata.scala
@@ -7,6 +7,4 @@ trait RecordMetadata {
 
   def deliveryId: Long
 
-  def deliveryStrategy: DeliveryStrategy
-
 }

--- a/kafka/src/main/scala/hydra/kafka/producer/KafkaRecordMetadata.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/KafkaRecordMetadata.scala
@@ -1,16 +1,15 @@
 package hydra.kafka.producer
 
-import hydra.core.transport.{RecordMetadata, DeliveryStrategy}
+import hydra.core.transport.RecordMetadata
 
 /**
   * Created by alexsilva on 2/22/17.
   */
 case class KafkaRecordMetadata(offset: Long, timestamp: Long, topic: String, partition: Int,
-                               deliveryId: Long, deliveryStrategy: DeliveryStrategy) extends RecordMetadata
+                               deliveryId: Long) extends RecordMetadata
 
 object KafkaRecordMetadata {
-  def apply(kmd: org.apache.kafka.clients.producer.RecordMetadata,
-            deliveryId: Long, rt: DeliveryStrategy): KafkaRecordMetadata = {
-    KafkaRecordMetadata(kmd.offset(), kmd.timestamp(), kmd.topic(), kmd.partition(), deliveryId, rt)
+  def apply(kmd: org.apache.kafka.clients.producer.RecordMetadata, deliveryId: Long): KafkaRecordMetadata = {
+    KafkaRecordMetadata(kmd.offset(), kmd.timestamp(), kmd.topic(), kmd.partition(), deliveryId)
   }
 }

--- a/kafka/src/main/scala/hydra/kafka/producer/PropagateExceptionCallback.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/PropagateExceptionCallback.scala
@@ -23,7 +23,7 @@ case class PropagateExceptionWithAckCallback(producer: ActorSelection,
       if (shouldAck) ingestor ! RecordNotProduced(record, e, Some(supervisor))
     }
     else {
-      val kmd = KafkaRecordMetadata(metadata, deliveryId, record.deliveryStrategy)
+      val kmd = KafkaRecordMetadata(metadata, deliveryId)
       producer ! kmd
       if (shouldAck) ingestor ! RecordProduced(kmd, Some(supervisor))
     }

--- a/kafka/src/main/scala/hydra/kafka/transport/KafkaProducerProxy.scala
+++ b/kafka/src/main/scala/hydra/kafka/transport/KafkaProducerProxy.scala
@@ -39,7 +39,7 @@ class KafkaProducerProxy(format: String, producerConfig: Config)
 
     case ProduceOnly(kr: KafkaRecord[Any, Any]) =>
       producer.send(kr, (metadata: RecordMetadata, e: Exception) => {
-        val msg = if (e != null) RecordNotProduced(kr, e) else KafkaRecordMetadata(metadata, 0, kr.deliveryStrategy)
+        val msg = if (e != null) RecordNotProduced(kr, e) else KafkaRecordMetadata(metadata, 0)
         self ! msg
       })
 

--- a/kafka/src/test/scala/hydra/kafka/producer/PropagateExceptionCallbackSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/PropagateExceptionCallbackSpec.scala
@@ -42,7 +42,7 @@ class PropagateExceptionCallbackSpec extends TestKit(ActorSystem("hydra")) with 
         record, AckStrategy.None, 112)
       val md = new RecordMetadata(new TopicPartition("test", 0), 0L, 1L, 1L, 1L, 1, 1)
       e.onCompletion(md, null)
-      probe.expectMsg(KafkaRecordMetadata(md, 112, record.deliveryStrategy))
+      probe.expectMsg(KafkaRecordMetadata(md, 112))
     }
 
     it("sends the error to the actor selection") {
@@ -61,8 +61,8 @@ class PropagateExceptionCallbackSpec extends TestKit(ActorSystem("hydra")) with 
         supervisor.ref, record, AckStrategy.Explicit, 112)
       val md = new RecordMetadata(new TopicPartition("test", 0), 0L, 1L, 1L, 1L: java.lang.Long, 1, 1)
       e.onCompletion(md, null)
-      probe.expectMsg(KafkaRecordMetadata(md, 112, record.deliveryStrategy))
-      ingestor.expectMsg(RecordProduced(KafkaRecordMetadata(md, 112, record.deliveryStrategy), Some(supervisor.ref)))
+      probe.expectMsg(KafkaRecordMetadata(md, 112))
+      ingestor.expectMsg(RecordProduced(KafkaRecordMetadata(md, 112), Some(supervisor.ref)))
     }
 
     it("sends the error to the actor selection and acks the ingestor") {

--- a/kafka/src/test/scala/hydra/kafka/transport/KafkaMetricsSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/transport/KafkaMetricsSpec.scala
@@ -5,7 +5,6 @@ import akka.testkit.{TestKit, TestProbe}
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.config.ConfigFactory
 import hydra.core.protocol.ProduceOnly
-import hydra.core.transport.DeliveryStrategy
 import hydra.kafka.producer.KafkaRecordMetadata
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 
@@ -32,7 +31,7 @@ class KafkaMetricsSpec extends TestKit(ActorSystem("hydra")) with Matchers with 
            |producers.kafka.metrics.actor_path="${probe.ref.path}"""".stripMargin)
       val pm = KafkaMetrics(cfg)
       pm shouldBe a[PublishMetrics]
-      pm.saveMetrics(KafkaRecordMetadata(1, 1, "topic", 1, 1, DeliveryStrategy.AtLeastOnce))
+      pm.saveMetrics(KafkaRecordMetadata(1, 1, "topic", 1, 1))
       probe.expectMsgType[ProduceOnly[String, JsonNode]]
     }
   }

--- a/kafka/src/test/scala/hydra/kafka/transport/KafkaProducerProxySpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/transport/KafkaProducerProxySpec.scala
@@ -4,7 +4,6 @@ import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import hydra.core.protocol.{ProduceOnly, RecordNotProduced, RecordProduced}
-import hydra.core.transport.DeliveryStrategy
 import hydra.kafka.config.KafkaConfigSupport
 import hydra.kafka.producer.{JsonRecord, KafkaRecordMetadata, StringRecord}
 import hydra.kafka.transport.KafkaProducerProxy.ProducerInitializationError
@@ -50,7 +49,7 @@ class KafkaProducerProxySpec extends TestKit(ActorSystem("hydra")) with Matchers
 
     it("sends metadata back to the parent") {
       val kafkaActor = parent.childActorOf(KafkaProducerProxy.props("string", kafkaProducerFormats("string")))
-      val kmd = KafkaRecordMetadata(recordMetadata, 0, DeliveryStrategy.AtMostOnce)
+      val kmd = KafkaRecordMetadata(recordMetadata, 0)
       kafkaActor ! kmd
       parent.expectMsgPF() {
         case RecordProduced(k, _) => k shouldBe kmd

--- a/sandbox/src/main/scala/hydra/sandbox/transport/FileRecord.scala
+++ b/sandbox/src/main/scala/hydra/sandbox/transport/FileRecord.scala
@@ -14,5 +14,4 @@ case class FileRecord(destination: String, payload: String, ackStrategy: AckStra
 }
 
 
-case class FileRecordMetadata(path: String, deliveryId: Long = 0L,
-                              deliveryStrategy: DeliveryStrategy) extends RecordMetadata
+case class FileRecordMetadata(path: String, deliveryId: Long = 0L) extends RecordMetadata

--- a/sandbox/src/main/scala/hydra/sandbox/transport/FileTransport.scala
+++ b/sandbox/src/main/scala/hydra/sandbox/transport/FileTransport.scala
@@ -39,7 +39,7 @@ class FileTransport(destinations: Map[String, String]) extends Transport {
         f.onComplete {
           case Success(_) =>
             //todo: look at the QueueOfferResult object
-            val md = FileRecordMetadata(destinations(r.destination), 0, r.deliveryStrategy)
+            val md = FileRecordMetadata(destinations(r.destination), 0)
             ingestor ! RecordProduced(md, Some(supervisor))
           case Failure(ex) => ingestor ! RecordNotProduced(r, ex, Some(supervisor))
         }

--- a/sandbox/src/test/scala/hydra/sandbox/transport/FileTransportSpec.scala
+++ b/sandbox/src/test/scala/hydra/sandbox/transport/FileTransportSpec.scala
@@ -5,12 +5,12 @@ import java.nio.file.Files
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import hydra.core.protocol.{Produce, ProduceOnly, RecordNotProduced, RecordProduced}
-import hydra.core.transport.{AckStrategy, DeliveryStrategy}
+import hydra.core.transport.AckStrategy
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.io.Source
 
 class FileTransportSpec extends TestKit(ActorSystem("hydra-sandbox-test")) with Matchers with FunSpecLike
@@ -53,7 +53,7 @@ class FileTransportSpec extends TestKit(ActorSystem("hydra-sandbox-test")) with 
       transport ! Produce(fr, ingestor.ref, supervisor.ref)
 
       ingestor.expectMsg(20.seconds, RecordProduced(FileRecordMetadata(files("test").getAbsolutePath,
-        0, DeliveryStrategy.AtMostOnce), Some(supervisor.ref)))
+        0), Some(supervisor.ref)))
 
       eventually(Source.fromFile(files("test")).getLines().toSeq should contain("test-payload1"))
     }


### PR DESCRIPTION
Removing deliveryStrategy from RecordMetadata trait; it should not be at that level and it wasn't used anywhere.