### PR TITLE
Making the App trait easier to extend and use.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ lazy val defaultSettings = Seq(
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   excludeDependencies += "org.slf4j" % "slf4j-log4j12",
   excludeDependencies += "log4j" % "log4j",
-  coverageEnabled := true,
   packageOptions in(Compile, packageBin) +=
     Package.ManifestAttributes("Implementation-Build" -> buildNumber),
   logLevel := Level.Info,

--- a/core/src/main/scala/hydra/core/app/HydraEntryPoint.scala
+++ b/core/src/main/scala/hydra/core/app/HydraEntryPoint.scala
@@ -6,7 +6,7 @@ import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import com.github.vonnagy.service.container.listener.ContainerLifecycleListener
 import com.github.vonnagy.service.container.service.ContainerService
 import com.github.vonnagy.service.container.{ContainerBuilder, MissingConfigException}
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
 import configs.syntax._
 import hydra.common.config.ConfigSupport
 import hydra.core.extensions.HydraExtensionListener
@@ -18,28 +18,23 @@ trait HydraEntryPoint extends App with SLF4JLogging with ConfigSupport {
 
   type ENDPOINT = Class[_ <: RoutedEndpoints]
 
-  def moduleName: String
-
-  def config: Config
+  def config: Config = rootConfig
 
   def services: Seq[(String, Props)]
 
-  def containerName: String = s"$applicationName-$moduleName"
-
-  def extensions = config.get[Config](s"$applicationName.extensions").valueOrElse(ConfigFactory.empty)
+  def containerName: String = s"$applicationName"
 
   def listeners: Seq[ContainerLifecycleListener] = Seq.empty
 
-  lazy val endpoints = config.get[List[String]](s"$applicationName.$moduleName.endpoints").valueOrElse(Seq.empty)
+  lazy val endpoints = config.get[List[String]](s"$applicationName.endpoints").valueOrElse(Seq.empty)
     .map(Class.forName(_).asInstanceOf[ENDPOINT])
 
   def buildContainer(): ContainerService = {
-    val hydraExts = if (extensions.isEmpty) Seq.empty else Seq(new HydraExtensionListener(moduleName, extensions))
     val builder = ContainerBuilder()
       .withConfig(config)
       .withRoutes(endpoints: _*)
       .withActors(services: _*)
-      .withListeners(hydraExts ++ listeners: _*)
+      .withListeners(new HydraExtensionListener(applicationConfig) +: listeners: _*)
       .withName(containerName)
 
     builder.build

--- a/core/src/main/scala/hydra/core/extensions/HydraExtensionListener.scala
+++ b/core/src/main/scala/hydra/core/extensions/HydraExtensionListener.scala
@@ -10,13 +10,13 @@ import hydra.common.logging.LoggingAdapter
   * Created by alexsilva on 2/1/16.
   *
   */
-class HydraExtensionListener(extensionName: String, config: Config) extends ContainerLifecycleListener
+class HydraExtensionListener(config: Config) extends ContainerLifecycleListener
   with LoggingAdapter {
 
   private[extensions] val hasExtensions = !config.isEmpty
 
   override def onStartup(container: ContainerService) = {
-    if (hasExtensions) HydraExtensionLoader.load(extensionName, config)(container.system)
+    if (hasExtensions) HydraExtensionLoader.load(config)(container.system)
   }
 
   override def onShutdown(container: ContainerService): Unit = {

--- a/core/src/test/scala/hydra/core/app/HydraEntryPointSpec.scala
+++ b/core/src/test/scala/hydra/core/app/HydraEntryPointSpec.scala
@@ -19,9 +19,9 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
   val conf =
     """
       |  hydra_test{
-      |  test {
-      |    endpoints = ["hydra.core.app.DummyEndpoint"]
-      | }
+      |
+      |  endpoints = ["hydra.core.app.DummyEndpoint"]
+      |
       | extensions {
       |    dummy {
       |      enabled = true
@@ -31,7 +31,6 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
     """.stripMargin
 
   val et = new HydraEntryPoint() {
-    override def moduleName: String = "test"
 
     override def config: Config = ConfigFactory.parseString(conf)
 
@@ -48,10 +47,8 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
   describe("When using the HydraEntryPoint class") {
 
     it("is properly configured") {
-      et.moduleName shouldBe "test"
-      et.services shouldBe Seq("test" -> Props[DummyActor])
+       et.services shouldBe Seq("test" -> Props[DummyActor])
       et.endpoints shouldBe Seq(classOf[DummyEndpoint])
-      et.extensions shouldBe ConfigFactory.parseString(conf).getConfig("hydra_test.extensions")
     }
 
 
@@ -63,7 +60,7 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
 
     it("builds a container") {
       val csvc = new ContainerService(Seq(classOf[DummyEndpoint]), Nil, Seq("test" -> Props[DummyActor]), Nil,
-        "hydra_test-test")(container.system)
+        "hydra_test")(container.system)
       csvc.name shouldBe container.name
       csvc.registeredRoutes shouldBe container.registeredRoutes
       csvc.name shouldBe container.name

--- a/core/src/test/scala/hydra/core/app/HydraEntryPointSpec.scala
+++ b/core/src/test/scala/hydra/core/app/HydraEntryPointSpec.scala
@@ -15,7 +15,6 @@ import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
   */
 class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterAll {
 
-
   val conf =
     """
       |  hydra_test{
@@ -31,7 +30,6 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
     """.stripMargin
 
   val et = new HydraEntryPoint() {
-
     override def config: Config = ConfigFactory.parseString(conf)
 
     override def services: Seq[(String, Props)] = Seq("test" -> Props[DummyActor])
@@ -47,10 +45,10 @@ class HydraEntryPointSpec extends Matchers with FunSpecLike with BeforeAndAfterA
   describe("When using the HydraEntryPoint class") {
 
     it("is properly configured") {
-       et.services shouldBe Seq("test" -> Props[DummyActor])
+      et.config shouldBe ConfigFactory.parseString(conf)
+      et.services shouldBe Seq("test" -> Props[DummyActor])
       et.endpoints shouldBe Seq(classOf[DummyEndpoint])
     }
-
 
     it("throws error if config is missing") {
       intercept[MissingConfigException] {

--- a/core/src/test/scala/hydra/core/extensions/HydraExtensionListenerSpec.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraExtensionListenerSpec.scala
@@ -20,7 +20,6 @@ class HydraExtensionListenerSpec extends TestKit(ActorSystem("test"))
     """.stripMargin
 
   val et = new HydraEntryPoint() {
-    override def moduleName: String = "test"
 
     override def config: Config = ConfigFactory.parseString(conf)
 
@@ -31,13 +30,15 @@ class HydraExtensionListenerSpec extends TestKit(ActorSystem("test"))
 
   val cfg = ConfigFactory.parseString(
     """
-      |test-extension {
-      |  name=typed-test
-      |  class=hydra.core.extensions.HydraTestExtension
+      |extensions {
+      |   test-extension {
+      |     name = typed-test
+      |     class = hydra.core.extensions.HydraTestExtension
+      |   }
       |}
     """.stripMargin)
 
-  val e = new HydraExtensionListener("test-extension", cfg)
+  val e = new HydraExtensionListener(cfg)
 
   override def afterAll() = {
     e.onShutdown(container)
@@ -53,7 +54,7 @@ class HydraExtensionListenerSpec extends TestKit(ActorSystem("test"))
     }
 
     it("skips loading on empty config") {
-      val e = new HydraExtensionListener("test-extension", ConfigFactory.empty())
+      val e = new HydraExtensionListener(ConfigFactory.empty())
       e.hasExtensions shouldBe false
       e.onStartup(container)
       e.onShutdown(container)

--- a/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
@@ -36,7 +36,7 @@ class HydraExtensionSpec extends TestKit(ActorSystem("test"))
   describe("Hydra extensions") {
     it("can be loaded from configuration") {
       val ext: Seq[Try[ExtensionId[_]]] = HydraExtensionLoader.load(cfg)
-      ext(1).isFailure shouldBe true
+     // ext(1).isFailure shouldBe true
       ext(0).get.asInstanceOf[ExtensionId[HydraTestExtensionImpl]].get(system).extName shouldBe "tester"
     }
 

--- a/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
@@ -26,12 +26,17 @@ class HydraExtensionSpec extends TestKit(ActorSystem("test"))
       |      enabled = true
       |      class = hydra.core.extensions.HydraTestExtension
       |    }
+      |    test-extension-disabled {
+      |      enabled = false
+      |      class = hydra.core.extensions.HydraTestExtension
+      |    }
       |  }
     """.stripMargin)
 
   describe("Hydra extensions") {
     it("can be loaded from configuration") {
       val ext: Seq[Try[ExtensionId[_]]] = HydraExtensionLoader.load(cfg)
+      ext(1).isFailure shouldBe true
       ext(0).get.asInstanceOf[ExtensionId[HydraTestExtensionImpl]].get(system).extName shouldBe "tester"
     }
 

--- a/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
@@ -5,6 +5,8 @@ import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import hydra.core.extensions.HydraActorModule.Run
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
 
+import scala.util.Try
+
 class HydraExtensionSpec extends TestKit(ActorSystem("test"))
   with Matchers with FunSpecLike with BeforeAndAfterAll with ImplicitSender {
 
@@ -29,8 +31,8 @@ class HydraExtensionSpec extends TestKit(ActorSystem("test"))
 
   describe("Hydra extensions") {
     it("can be loaded from configuration") {
-      val ext = HydraExtensionLoader.load("test-extension", cfg.getConfig("extensions"))
-      ext.get.asInstanceOf[ExtensionId[HydraTestExtensionImpl]].get(system).extName shouldBe "tester"
+      val ext: Seq[Try[ExtensionId[_]]] = HydraExtensionLoader.load(cfg)
+      ext(0).get.asInstanceOf[ExtensionId[HydraTestExtensionImpl]].get(system).extName shouldBe "tester"
     }
 
     it("register modules with the extension registry") {

--- a/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraExtensionSpec.scala
@@ -26,18 +26,29 @@ class HydraExtensionSpec extends TestKit(ActorSystem("test"))
       |      enabled = true
       |      class = hydra.core.extensions.HydraTestExtension
       |    }
-      |    test-extension-disabled {
-      |      enabled = false
-      |      class = hydra.core.extensions.HydraTestExtension
-      |    }
       |  }
     """.stripMargin)
 
   describe("Hydra extensions") {
     it("can be loaded from configuration") {
       val ext: Seq[Try[ExtensionId[_]]] = HydraExtensionLoader.load(cfg)
-     // ext(1).isFailure shouldBe true
       ext(0).get.asInstanceOf[ExtensionId[HydraTestExtensionImpl]].get(system).extName shouldBe "tester"
+    }
+
+    it("reports failure") {
+      val cfg = ConfigFactory.parseString(
+        """
+          |    extensions {
+          |      test-extension-disabled {
+          |      enabled = false
+          |      class = hydra.core.extensions.HydraTestExtension
+          |    }
+          |  }
+        """.stripMargin)
+      val ext: Seq[Try[ExtensionId[_]]] = HydraExtensionLoader.load(cfg)
+      intercept[IllegalArgumentException] {
+        ext(0).get
+      }
     }
 
     it("register modules with the extension registry") {

--- a/core/src/test/scala/hydra/core/extensions/HydraTestExtensionImpl.scala
+++ b/core/src/test/scala/hydra/core/extensions/HydraTestExtensionImpl.scala
@@ -52,7 +52,10 @@ class TestTypedModule(val id: String, val config: Config) extends HydraTypedModu
 
 
 class TestActorModule(val id: String, val config: Config) extends HydraActorModule {
-  val act = context.actorSelection(config.getString("actorPath"))
+
+  import configs.syntax._
+
+  val act = context.actorSelection(config.getOrElse[String]("actorPath", "").value)
 
   override def run(): Unit = act ! Run
 

--- a/project/Test.scala
+++ b/project/Test.scala
@@ -14,6 +14,7 @@ object Test {
 
     // Don't package test jars since it does not handle resources properly
     exportJars in sbt.Test := false,
+    coverageEnabled in sbt.Test := true,
 
     // Include the code coverage settings
     coverageExcludedPackages := "<empty>;akka.contrib.*",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,4 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+

--- a/sandbox/src/main/scala/hydra/sandbox/app/HydraIngest.scala
+++ b/sandbox/src/main/scala/hydra/sandbox/app/HydraIngest.scala
@@ -11,9 +11,8 @@ import hydra.ingest.IngestionActors
   */
 // $COVERAGE-OFF$
 object HydraIngest extends HydraEntryPoint with IngestionActors {
-  override def moduleName: String = "sandbox"
 
-  override def config = rootConfig.withFallback(ConfigFactory.parseFile(new File("/etc/hydra/hydra-sandbox.conf")))
+  override val config = rootConfig.withFallback(ConfigFactory.parseFile(new File("/etc/hydra/hydra-sandbox.conf")))
 
   buildContainer().start()
 }


### PR DESCRIPTION
This changes how extensions are loaded so that names are no longer required and are extracted from the configuration file.  With this change, we no longer need to specify a module name in the App trait, which will make the App easier to run for users.