### PR TITLE
fixing jdbc catalog missing column bug

### DIFF
--- a/sql/src/main/scala/hydra/sql/JdbcCatalog.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcCatalog.scala
@@ -106,10 +106,10 @@ class JdbcCatalog(ds: DataSource, dbSyntax: DbSyntax, dialect: JdbcDialect) exte
 
   def findMissingFields(schema: Schema, columns: Seq[DbColumn]): Seq[Field] = {
     import scala.collection.JavaConverters._
-    val fields = schema.getFields.asScala
+    val fields = schema.getFields.asScala.map(f => dbSyntax.format(f.name) -> f).toMap
     val cols = columns.map(_.name).toSet
-    val missing = fields.map(_.name()).filterNot(cols)
-    missing.map(schema.getField)
+    val missing = fields -- cols
+    missing.values.toSeq
   }
 
   override def tableExists(tId: TableIdentifier): Boolean = synchronized {

--- a/sql/src/test/scala/hydra/sql/JdbcCatalogSpec.scala
+++ b/sql/src/test/scala/hydra/sql/JdbcCatalogSpec.scala
@@ -166,6 +166,36 @@ class JdbcCatalogSpec extends Matchers with FunSpecLike with BeforeAndAfterAll {
         DbColumn("optional", JDBCType.CLOB, true, Some("")))
       store.getTableMetadata(TableIdentifier("test_table", None, Some(""))).get shouldBe DbTable("test_table", cols, None)
     }
-  }
 
+    it("finds the missing fields for a schema") {
+      val sc = new Schema.Parser().parse(
+        """
+          |{
+          |	"type": "record",
+          |	"name": "User",
+          |	"namespace": "hydra",
+          |	"fields": [{
+          |			"name": "id",
+          |			"type": "int"
+          |		},
+          |		{
+          |			"name": "firstName",
+          |			"type": "string"
+          |		},
+          |  {
+          |			"name": "lastName",
+          |			"type": "string"
+          |		}
+          |	]
+          |}""".stripMargin)
+
+      val cols = List(
+        DbColumn("id", JDBCType.INTEGER, false, Some("")),
+        DbColumn("first_name", JDBCType.INTEGER, true, Some("")))
+
+      val catalog = new JdbcCatalog(ds, UnderscoreSyntax, PostgresDialect)
+
+      catalog.findMissingFields(sc, cols) shouldBe Seq(sc.getField("lastName"))
+    }
+  }
 }


### PR DESCRIPTION
If there was underscores in the database column names, the catalog would try to create the entire table again on any schema change because of names being mismatched.  This PR fixes that by creating a map where the key is the db name and the value is the schema field.