### PR TITLE
Cluster

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val defaultSettings = Seq(
   resolvers += "jitpack" at "https://jitpack.io",
   resolvers += Resolver.bintrayRepo("hseeberger", "maven"),
   ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
-  parallelExecution in Test := false
+  parallelExecution in sbt.Test := false
 )
 
 lazy val restartSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val defaultSettings = Seq(
   resolvers += "Confluent Maven Repo" at "http://packages.confluent.io/maven/",
   resolvers += "jitpack" at "https://jitpack.io",
   resolvers += Resolver.bintrayRepo("hseeberger", "maven"),
-  ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet
+  ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
+  parallelExecution in Test := false
 )
 
 lazy val restartSettings = Seq(

--- a/core/src/main/scala/hydra/core/akka/ClusterWatcher.scala
+++ b/core/src/main/scala/hydra/core/akka/ClusterWatcher.scala
@@ -1,0 +1,48 @@
+package hydra.core.akka
+
+import akka.actor.Actor
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberEvent, MemberRemoved, MemberUp}
+import akka.cluster.{Cluster, Member, MemberStatus}
+import hydra.core.akka.ClusterWatcher.{GetNodes, GetNodesByRole}
+
+class ClusterWatcher extends Actor {
+
+  private val cluster = Cluster(context.system)
+
+  override def preStart(): Unit = cluster.subscribe(self, classOf[MemberEvent])
+
+  override def postStop(): Unit = cluster unsubscribe self
+
+  private[akka] var nodes = Set.empty[Member]
+
+  //for testing
+  def getNodes: Seq[Member] =nodes.toSeq
+
+
+  override def receive = {
+    case state: CurrentClusterState =>
+      nodes = state.members.collect { case m if m.status == MemberStatus.Up => m }
+
+    case MemberUp(member) =>
+      nodes += member
+
+    case MemberRemoved(member, _) =>
+      nodes -= member
+
+    case GetNodes =>
+      sender ! nodes.map(_.address).toList
+
+    case GetNodesByRole(role) =>
+      sender ! nodes.filter(_.hasRole(role)).map(_.address).toList
+
+    case _: MemberEvent ⇒ // ignore
+  }
+}
+
+object ClusterWatcher {
+
+  case object GetNodes
+
+  case class GetNodesByRole(role: String)
+
+}

--- a/core/src/main/scala/hydra/core/akka/ClusterWatcher.scala
+++ b/core/src/main/scala/hydra/core/akka/ClusterWatcher.scala
@@ -15,8 +15,8 @@ class ClusterWatcher extends Actor {
 
   private[akka] var nodes = Set.empty[Member]
 
-  //for testing
-  def getNodes: Seq[Member] =nodes.toSeq
+  //for testing only
+  def getNodes: Seq[Member] = nodes.toSeq
 
 
   override def receive = {
@@ -35,7 +35,7 @@ class ClusterWatcher extends Actor {
     case GetNodesByRole(role) =>
       sender ! nodes.filter(_.hasRole(role)).map(_.address).toList
 
-    case _: MemberEvent ⇒ // ignore
+    case _: MemberEvent => // ignore
   }
 }
 

--- a/core/src/test/scala/akka/cluster/ClusterWatchSpec.scala
+++ b/core/src/test/scala/akka/cluster/ClusterWatchSpec.scala
@@ -1,0 +1,102 @@
+package akka.cluster
+
+import akka.actor.{ActorSystem, Address, Props}
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberRemoved, MemberUp, MemberWeaklyUp}
+import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import com.typesafe.config.ConfigFactory
+import hydra.core.akka.ClusterWatcher
+import hydra.core.akka.ClusterWatcher.{GetNodes, GetNodesByRole}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpecLike, Matchers}
+
+import scala.collection.immutable.SortedSet
+import scala.concurrent.duration._
+import scala.util.Random
+
+class ClusterWatchSpec extends TestKit(ActorSystem("hydra",
+  config = ConfigFactory.parseString("akka.actor.provider=cluster")
+    .withFallback(ConfigFactory.load()))) with Matchers with FlatSpecLike
+  with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  def host = Random.alphanumeric.dropWhile(_.isDigit) take 10 mkString
+
+  def address = UniqueAddress(Address("akka", "hydra", host, 1234), Math.abs(Random.nextLong))
+
+  var listener: TestActorRef[ClusterWatcher] = _
+
+  override def afterAll = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+  }
+
+  override def beforeEach = {
+    listener = TestActorRef[ClusterWatcher](Props[ClusterWatcher])
+  }
+
+  override def afterEach = {
+    system.stop(listener)
+  }
+
+  "The ClusterWatchSpec" should "add members to list" in {
+    val probe = TestProbe()
+    val a = address
+    listener ! MemberUp(new Member(a, 1, MemberStatus.Up, Set("dc-test", "test")))
+    awaitCond(!listener.underlyingActor.getNodes.isEmpty)
+    listener.tell(GetNodes, probe.ref)
+    probe.expectMsgPF(max = 10.seconds) {
+      case n :: Nil =>
+        n.asInstanceOf[Address] shouldBe a.address
+    }
+  }
+
+  it should "list members by role" in {
+    val probe = TestProbe()
+    val address2 = address
+    listener ! MemberUp(new Member(address, 2, MemberStatus.Up, Set("dc-test", "role1")))
+    listener ! MemberUp(new Member(address2, 3, MemberStatus.Up, Set("dc-test", "role2")))
+    awaitCond(listener.underlyingActor.getNodes.length == 2, max = 5.seconds)
+    listener.tell(GetNodesByRole("role2"), probe.ref)
+    probe.expectMsgPF(max = 5.seconds) {
+      case n :: Nil =>
+        n.asInstanceOf[Address] shouldBe address2.address
+    }
+  }
+
+  it should "accept cluster state messages" in {
+    val probe = TestProbe()
+    val a = address
+    val members = SortedSet(new Member(a, 2, MemberStatus.Up, Set("dc-test", "role1")))
+    listener ! CurrentClusterState(members)
+    listener.tell(GetNodes, probe.ref)
+    probe.expectMsgPF() {
+      case n1 :: Nil =>
+        n1.asInstanceOf[Address] shouldBe a.address
+    }
+  }
+
+  it should "ignore MemberWeaklyUp events" in {
+    val probe = TestProbe()
+    listener.tell(MemberWeaklyUp(new Member(address, 4, MemberStatus.WeaklyUp,
+      Set("dc-test", "test"))), probe.ref)
+    probe.expectNoMessage(remainingOrDefault)
+  }
+
+  it should "remove members to list" in {
+    val probe = TestProbe()
+    val addr = address
+    listener ! MemberUp(new Member(addr, 4, MemberStatus.Up, Set("dc-test", "test")))
+    awaitCond(listener.underlyingActor.getNodes.length == 1, max = 5.seconds)
+
+    listener.tell(GetNodes, probe.ref)
+    probe.expectMsgPF() {
+      case n :: Nil =>
+        n.asInstanceOf[Address].system shouldBe "hydra"
+    }
+
+    listener ! MemberRemoved(new Member(addr, 4, MemberStatus.Removed, Set("dc-test")),
+      MemberStatus.Up)
+    awaitCond(listener.underlyingActor.getNodes.isEmpty, max = 5.seconds)
+
+    listener.tell(GetNodes, probe.ref)
+    probe.expectMsg(Nil)
+
+  }
+}

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionHandlerGatewayClusterSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionHandlerGatewayClusterSpec.scala
@@ -46,7 +46,6 @@ class IngestionHandlerGatewayClusterSpec extends TestKit(ActorSystem("hydra",
     }
   }, "ingestor_registry")
 
-
   val props = IngestionHandlerGateway.props(registry.path.toString)
 
   val gateway = system.actorOf(props)


### PR DESCRIPTION
Adding ClusterListener actor that can be distributed across the cluster, so that nodes can query the cluster for nodes with specific roles.