### PR TITLE
adding hydra.client.id to allow routing of requests to the same trans…

### DIFF
--- a/core/src/main/scala/hydra/core/ingest/HydraRequest.scala
+++ b/core/src/main/scala/hydra/core/ingest/HydraRequest.scala
@@ -10,6 +10,7 @@ import hydra.core.transport.{AckStrategy, ValidationStrategy}
   */
 case class HydraRequest(correlationId: String = CorrelationIdBuilder.generate(),
                         payload: String,
+                        clientId: Option[String] = None,
                         metadata: Map[String, String] = Map.empty,
                         validationStrategy: ValidationStrategy = Strict,
                         ackStrategy: AckStrategy = AckStrategy.NoAck) {

--- a/core/src/main/scala/hydra/core/ingest/RequestParams.scala
+++ b/core/src/main/scala/hydra/core/ingest/RequestParams.scala
@@ -90,6 +90,8 @@ object RequestParams {
     */
   val HYDRA_ACK_STRATEGY = "hydra-ack"
 
+  val HydraClientId = "hydra-client-id"
+
 
   /**
     * The amount of time, in milliseconds, to wait before a timeout error is returned to the client.

--- a/ingest/src/main/scala/hydra.ingest/http/HttpRequestFactory.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/HttpRequestFactory.scala
@@ -25,10 +25,13 @@ class HttpRequestFactory extends RequestFactory[HttpRequest] with CodingDirectiv
     lazy val as = request.headers.find(_.lowercaseName() == HYDRA_ACK_STRATEGY)
       .map(h => AckStrategy(h.value())).getOrElse(AckStrategy.NoAck)
 
+    lazy val clientId = request.headers.find(_.lowercaseName() == HydraClientId)
+      .map(_.value().toLowerCase)
+
     Unmarshal(request.entity).to[String].map { payload =>
       val dPayload = if (request.method == HttpMethods.DELETE && payload.isEmpty) null else payload
       val metadata: Map[String, String] = request.headers.map(h => h.name.toLowerCase -> h.value).toMap
-      HydraRequest(correlationId, dPayload, metadata, validationStrategy = vs, ackStrategy = as)
+      HydraRequest(correlationId, dPayload, clientId, metadata, vs, as)
     }
   }
 }

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
@@ -105,7 +105,9 @@ case class SocketSession(metadata: Map[String, String] = Map.empty) {
     val as = metadata.find(_._1.equalsIgnoreCase(HYDRA_ACK_STRATEGY))
       .map(h => AckStrategy(h._2)).getOrElse(AckStrategy.NoAck)
 
-    ingest.HydraRequest(correlationId.getOrElse("0"), payload, metadata,
-      validationStrategy = vs, ackStrategy = as)
+    lazy val clientId = metadata.find(_._1.toLowerCase() == HydraClientId)
+      .map(_._2.toLowerCase)
+
+    ingest.HydraRequest(correlationId.getOrElse("0"), payload, clientId, metadata,vs, as)
   }
 }

--- a/ingest/src/test/scala/hydra/ingest/http/HttpRequestFactorySpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/HttpRequestFactorySpec.scala
@@ -29,6 +29,7 @@ class HttpRequestFactorySpec extends TestKit(ActorSystem()) with Matchers with F
         HttpMethods.POST,
         headers = Seq(RawHeader("hydra", "awesome"),
           RawHeader(RequestParams.HYDRA_VALIDATION_STRATEGY, "relaxed"),
+          RawHeader(RequestParams.HydraClientId, "test-client"),
           RawHeader(RequestParams.HYDRA_ACK_STRATEGY, "replicated")),
         uri = "/test",
         entity = HttpEntity(MediaTypes.`application/json`, json))
@@ -37,6 +38,7 @@ class HttpRequestFactorySpec extends TestKit(ActorSystem()) with Matchers with F
         req.payload shouldBe json
         req.correlationId shouldBe "123"
         req.metadataValue("hydra") shouldBe Some("awesome")
+        req.clientId shouldBe Some("test-client")
         req.validationStrategy shouldBe ValidationStrategy.Relaxed
         req.ackStrategy shouldBe AckStrategy.Replicated
       }

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -103,6 +103,8 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
 
         wsClient.sendMessage("-c SET hydra-delivery-strategy = at-most-once")
         wsClient.expectMessage("""{"status":200,"message":"OK[HYDRA-DELIVERY-STRATEGY=at-most-once]"}""")
+        wsClient.sendMessage("-c SET hydra-client-id = test-client")
+        wsClient.expectMessage("""{"status":200,"message":"OK[HYDRA-CLIENT-ID=test-client]"}""")
 
         wsClient.sendMessage("""-i 122 {"name":"test","value":"test"}""")
         wsClient.expectMessage("""{"correlationId":"122","ingestors":{"test_ingestor":{"code":200,"message":"OK"}}}""")

--- a/jdbc/src/test/scala/hydra/jdbc/JdbcIngestorSpec.scala
+++ b/jdbc/src/test/scala/hydra/jdbc/JdbcIngestorSpec.scala
@@ -25,7 +25,8 @@ class JdbcIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
   describe("When using the jdbc ingestor") {
     it("Joins") {
-      val request = HydraRequest("123", "someString", Map(JdbcRecordFactory.DB_PROFILE_PARAM -> "testdb"))
+      val request = HydraRequest("123", "someString", None,
+        Map(JdbcRecordFactory.DB_PROFILE_PARAM -> "testdb"))
       ingestor ! Publish(request)
       expectMsg(Join)
     }

--- a/kafka/src/main/scala/hydra/kafka/config/KafkaConfigSupport.scala
+++ b/kafka/src/main/scala/hydra/kafka/config/KafkaConfigSupport.scala
@@ -20,6 +20,7 @@ import java.util.Properties
 import com.typesafe.config._
 import configs.syntax._
 import hydra.common.config.ConfigSupport
+import hydra.common.logging.LoggingAdapter
 
 import scala.collection.JavaConverters._
 
@@ -95,11 +96,27 @@ trait KafkaConfigSupport extends ConfigSupport {
   }
 }
 
-object KafkaConfigSupport extends ConfigSupport {
+object KafkaConfigSupport extends ConfigSupport with LoggingAdapter {
 
   val schemaRegistryUrl = applicationConfig.getString("schema.registry.url")
 
   private val schemaRegistryConfig = ConfigFactory.parseString(s"""schema.registry.url="$schemaRegistryUrl"""")
+
+  lazy val configClients: Map[String, Map[String, String]] = clients(applicationConfig)
+
+  def clients(config: Config): Map[String, Map[String, String]] = {
+    val producerDefaults = config.get[Config]("kafka.producer")
+      .valueOrElse(ConfigFactory.empty)
+      .withFallback(schemaRegistryConfig)
+
+    val clients = config.get[Config]("kafka.clients").valueOrElse(ConfigFactory.empty)
+    clients.root().asScala.map { case (clientId, config) =>
+      val clientIdCfg = ConfigFactory.parseString(s"client.id=$clientId")
+      val clientCfg = config.withFallback(clientIdCfg).withFallback(producerDefaults)
+      clientId -> ConfigSupport.toMap(clientIdCfg
+        .withFallback(clientCfg)).mapValues(_.toString)
+    }.toMap
+  }
 
   def loadConsumerFormats(cfg: Config): Map[String, Config] = {
     val formats = cfg.getObject("kafka.formats").entrySet.asScala.toSeq

--- a/kafka/src/main/scala/hydra/kafka/config/KafkaConfigSupport.scala
+++ b/kafka/src/main/scala/hydra/kafka/config/KafkaConfigSupport.scala
@@ -20,7 +20,6 @@ import java.util.Properties
 import com.typesafe.config._
 import configs.syntax._
 import hydra.common.config.ConfigSupport
-import hydra.common.logging.LoggingAdapter
 
 import scala.collection.JavaConverters._
 
@@ -96,7 +95,7 @@ trait KafkaConfigSupport extends ConfigSupport {
   }
 }
 
-object KafkaConfigSupport extends ConfigSupport with LoggingAdapter {
+object KafkaConfigSupport extends ConfigSupport {
 
   val schemaRegistryUrl = applicationConfig.getString("schema.registry.url")
 

--- a/kafka/src/test/resources/reference.conf
+++ b/kafka/src/test/resources/reference.conf
@@ -55,5 +55,12 @@ hydra_test {
         client.id = "hydra.avro"
       }
     }
+
+    clients {
+      tester-cfg {
+        key.serializer = "org.apache.kafka.common.serialization.StringSerializer"
+        value.serializer = "io.confluent.kafka.serializers.KafkaAvroSerializer"
+      }
+    }
   }
 }

--- a/kafka/src/test/scala/hydra/kafka/ingestors/IngestionErrorHandlerSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/ingestors/IngestionErrorHandlerSpec.scala
@@ -39,7 +39,7 @@ class IngestionErrorHandlerSpec extends TestKit(ActorSystem("hydra-test")) with 
 
   val schema = new Schema.Parser().parse(Source.fromResource("schemas/HydraIngestError.avsc").mkString)
 
-  val request = HydraRequest("123", "someString", Map(HYDRA_KAFKA_TOPIC_PARAM -> "topic"))
+  val request = HydraRequest("123", "someString", None, Map(HYDRA_KAFKA_TOPIC_PARAM -> "topic"))
 
   describe("When using the kafka ingestion error handler") {
     it("builds an avro record") {

--- a/kafka/src/test/scala/hydra/kafka/ingestors/KafkaIngestorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/ingestors/KafkaIngestorSpec.scala
@@ -64,7 +64,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
   describe("when using the KafkaIngestor") {
     it("joins") {
       val request = HydraRequest("123",
-        "someString",
+        "someString", None,
         Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_KAFKA_TOPIC_PARAM -> "topic")
       )
       kafkaIngestor ! Publish(request)
@@ -73,7 +73,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
     it("is invalid when there is no topic") {
       val request = HydraRequest("123",
-        "someString",
+        "someString", None,
         Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_RECORD_FORMAT_PARAM -> "json")
       )
       kafkaIngestor ! Validate(request)
@@ -82,7 +82,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
     it("ingests") {
       val request = HydraRequest("123",
-        """{"first":"Roar","last":"King"}""",
+        """{"first":"Roar","last":"King"}""", None,
         Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_KAFKA_TOPIC_PARAM -> "test-schema")
       )
       whenReady(TestRecordFactory.build(request)) { record =>
@@ -98,7 +98,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
   it("is invalid if it can't find the schema") {
     val request = HydraRequest("213",
-      "someString",
+      "someString", None,
       Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_KAFKA_TOPIC_PARAM -> "avro-topic")
     )
     kafkaIngestor ! Validate(request)
@@ -107,7 +107,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
   it("is valid with no schema if the topic can be resolved to a string") {
     val request = HydraRequest("123",
-      json,
+      json, None,
       Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_KAFKA_TOPIC_PARAM -> "test-schema")
     )
     kafkaIngestor ! Validate(request)
@@ -117,7 +117,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
 
   it("is valid when a schema name overrides the topic name") {
     val request = HydraRequest("123",
-      json,
+      json, None,
       Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_KAFKA_TOPIC_PARAM -> "just-a-topic", HYDRA_SCHEMA_PARAM -> "test-schema")
     )
     avroRecordFactory.getTopicAndSchemaSubject(request).get._2 shouldBe "test-schema"
@@ -126,7 +126,7 @@ class KafkaIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matchers
     expectMsg(ValidRequest(ar))
   }
   it("is valid if schema can't be found, but json is allowed") {
-    val request = HydraRequest("123", json,
+    val request = HydraRequest("123", json, None,
       Map(HYDRA_INGESTOR_PARAM -> KAFKA, HYDRA_RECORD_FORMAT_PARAM -> "json", HYDRA_KAFKA_TOPIC_PARAM -> "json-topic"))
     kafkaIngestor ! Validate(request)
     val node = new ObjectMapper().reader().readTree("""{"first":"hydra","last":"hydra"}""")

--- a/rabbitmq/src/test/scala/hydra/rabbit/RabbitIngestorSpec.scala
+++ b/rabbitmq/src/test/scala/hydra/rabbit/RabbitIngestorSpec.scala
@@ -40,13 +40,15 @@ class RabbitIngestorSpec extends TestKit(ActorSystem("hydra-test")) with Matcher
 
   describe("When using the rabbit ingestor") {
     it("Joins if exchange provided") {
-      val request = HydraRequest("123", "{'name': 'test'}", Map(RabbitRecord.HYDRA_RABBIT_EXCHANGE -> "test.exchange"))
+      val request = HydraRequest("123", "{'name': 'test'}", None,
+        Map(RabbitRecord.HYDRA_RABBIT_EXCHANGE -> "test.exchange"))
       ingestor ! Publish(request)
       expectMsg(10.seconds, Join)
     }
 
     it("Joins if queue provided") {
-      val request = HydraRequest("123", "{'name': 'test'}", Map(RabbitRecord.HYDRA_RABBIT_QUEUE -> "test.queue"))
+      val request = HydraRequest("123", "{'name': 'test'}", None,
+        Map(RabbitRecord.HYDRA_RABBIT_QUEUE -> "test.queue"))
       ingestor ! Publish(request)
       expectMsg(10.seconds, Join)
     }


### PR DESCRIPTION
adding hydra.client.id to allow routing of requests to the same transport across requests and nodes in the same cluster.