### PR TITLE
version postgres table when avro schema is versioned

### DIFF
--- a/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
@@ -52,7 +52,7 @@ class JdbcRecordWriter(val settings: JdbcWriterSettings,
 
   private val store: Catalog = new JdbcCatalog(connectionProvider, syntax, dialect)
 
-  private val tableId = tableIdentifier.getOrElse(TableIdentifier(schemaWrapper.getName))
+  private val tableId = tableIdentifier.getOrElse(TableIdentifier(JdbcUtils.createTableNameFromSchema(schemaWrapper.schema)))
 
   private val operations = new mutable.ArrayBuffer[Operation]()
 

--- a/sql/src/main/scala/hydra/sql/JdbcUtils.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcUtils.scala
@@ -168,4 +168,18 @@ private[sql] object JdbcUtils {
     dialect.getJDBCType(schema).orElse(getCommonJDBCType(schema)).getOrElse(
       throw new IllegalArgumentException(s"Can't get JDBC type for ${schema.getName}"))
   }
+
+  def createTableNameFromSchema(schema: Schema): String = {
+    val namespace = schema.getNamespace
+    val name = schema.getName
+    val versionMatcher = """.*\.(v\d+)$""".r
+    namespace match {
+      case versionMatcher(version) => {
+        name + version.toUpperCase()
+      }
+      case _ => {
+        name
+      }
+    }
+  }
 }

--- a/sql/src/test/scala/hydra/sql/JdbcRecordWriterSpec.scala
+++ b/sql/src/test/scala/hydra/sql/JdbcRecordWriterSpec.scala
@@ -482,5 +482,27 @@ class JdbcRecordWriterSpec extends Matchers
         rs.next() shouldBe false
       }.get
     }
+
+    it("writes to new a versioned table if schema is versioned") {
+      val schemaStrV2 = """{
+                          |  "type": "record",
+                          |  "name": "VersionedTable",
+                          |  "namespace": "hydra.v2",
+                          |  "fields": [{
+                          |    "name": "identifier",
+                          |    "type": "int"
+                          |  },
+                          |  {
+                          |    "name": "name",
+                          |    "type": "string"
+                          |  }]
+                          |}""".stripMargin
+
+      val schemaVersion2 = new Schema.Parser().parse(schemaStrV2)
+
+      new JdbcRecordWriter( writerSettings, provider, SchemaWrapper.from(schemaVersion2), SaveMode.Append).close()
+      catalog.tableExists(TableIdentifier("versioned_table_v2")) shouldBe true
+    }
+
   }
 }

--- a/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
+++ b/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
@@ -357,5 +357,27 @@ class JdbcUtilsSpec extends Matchers with FunSpecLike {
       stmt shouldBe "\"id1\" INTEGER NOT NULL,\"id2\" INTEGER NOT NULL,\"username\" TEXT NOT NULL," +
         "\"testEnum\" TEXT NOT NULL,CONSTRAINT User_PK PRIMARY KEY (\"id1\",\"id2\")"
     }
+
+    it("Generates the correct table name from a versioned schema") {
+      val schema =
+        """
+          |{
+          |	"type": "record",
+          |	"name": "MyTable",
+          |	"namespace": "hydra.v3",
+          | "hydra.key":"id1,id2",
+          |	"fields": [
+          | {
+          |			"name": "id1",
+          |			"type": "int"
+          |		}
+          |	]
+          |}
+        """.stripMargin
+
+      val avro = new Schema.Parser().parse(schema)
+      val tableName = JdbcUtils.createTableNameFromSchema(avro)
+      tableName shouldBe "MyTableV3"
+    }
   }
 }


### PR DESCRIPTION
For example, if the avro schema namespace is "com.example.v2" and name is "MyTable" then the table name will be my_table_v2 when materialized in the database.