### PR TITLE
Add validation for Ack Strategy

### DIFF
--- a/core/src/main/scala/hydra/core/marshallers/HydraJsonSupport.scala
+++ b/core/src/main/scala/hydra/core/marshallers/HydraJsonSupport.scala
@@ -34,6 +34,8 @@ import scala.util.{Failure, Success, Try}
   */
 trait HydraJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
+  implicit val genericErrorFormat = jsonFormat2(GenericError)
+
   implicit object StatusCodeJsonFormat extends JsonFormat[StatusCode] {
 
     override def write(t: StatusCode): JsValue =
@@ -127,6 +129,8 @@ trait HydraJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
       }
     }
   }
-
 }
+
+case class GenericError(status: Int, errorMessage: String)
+
 

--- a/core/src/main/scala/hydra/core/transport/AckStrategy.scala
+++ b/core/src/main/scala/hydra/core/transport/AckStrategy.scala
@@ -1,5 +1,7 @@
 package hydra.core.transport
 
+import scala.util.Try
+
 /**
   * Defines an Ack Strategy for messages being sent by a producer.
   *
@@ -13,11 +15,15 @@ sealed trait AckStrategy
 
 object AckStrategy {
 
-  def apply(strategy: String): AckStrategy = {
-    Option(strategy).map(_.trim.toLowerCase) match {
-      case Some("replicated") => Replicated
-      case Some("persisted") => Persisted
-      case _ => NoAck
+  def apply(strategy: String): Try[AckStrategy] = {
+    Try {
+      Option(strategy).map(_.trim.toLowerCase).collect {
+        case "replicated" => Replicated
+        case "persisted" => Persisted
+        case "noack" => NoAck
+        case s if s.isEmpty => NoAck
+        case x => throw new IllegalArgumentException(s"$x is not a valid ack strategy.")
+      }.getOrElse(NoAck)
     }
   }
 

--- a/core/src/test/scala/hydra/core/connect/ConnectorSettingSpec.scala
+++ b/core/src/test/scala/hydra/core/connect/ConnectorSettingSpec.scala
@@ -7,8 +7,9 @@ import hydra.core.transport.{AckStrategy, ValidationStrategy}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.concurrent.duration._
+import scala.util.Success
 
-class ConnectorSettingSpec extends TestKit(ActorSystem("test"))
+class ConnectorSettingSpec extends TestKit(ActorSystem("ConnectorSettingSpec"))
   with Matchers
   with FlatSpecLike
   with BeforeAndAfterAll {
@@ -30,7 +31,7 @@ class ConnectorSettingSpec extends TestKit(ActorSystem("test"))
     val settings = new ConnectorSettings(config, system)
     settings.clustered shouldBe false //read from system
     settings.requestTimeout shouldBe 2.seconds
-    settings.ackStrategy shouldBe AckStrategy.Replicated
+    settings.ackStrategy shouldBe Success(AckStrategy.Replicated)
     settings.validationStrategy shouldBe ValidationStrategy.Relaxed
     settings.charset shouldBe "test"
     settings.metadata shouldBe Map("test" -> "true")

--- a/core/src/test/scala/hydra/core/transport/AckStrategySpec.scala
+++ b/core/src/test/scala/hydra/core/transport/AckStrategySpec.scala
@@ -1,14 +1,22 @@
 package hydra.core.transport
 
+import hydra.core.transport.AckStrategy.NoAck
 import org.scalatest.{FlatSpecLike, Matchers}
 
-class AckStrategySpec extends Matchers with FlatSpecLike{
+class AckStrategySpec extends Matchers with FlatSpecLike {
 
   "the ack strategy companion" should "parse strings" in {
-    AckStrategy("replicated") shouldBe AckStrategy.Replicated
-    AckStrategy("persIsted") shouldBe AckStrategy.Persisted
-    AckStrategy("none") shouldBe AckStrategy.NoAck
-    AckStrategy("unknown") shouldBe AckStrategy.NoAck
-    AckStrategy(null) shouldBe AckStrategy.NoAck
+    AckStrategy("replicated").get shouldBe AckStrategy.Replicated
+    AckStrategy("persIsted").get shouldBe AckStrategy.Persisted
+    intercept[IllegalArgumentException] {
+      AckStrategy("none").get
+    }
+    intercept[IllegalArgumentException] {
+      AckStrategy("unknown").get
+    }
+
+    //the "default" options, if no Ack is specified
+    AckStrategy(null).get shouldBe NoAck
+    AckStrategy("").get shouldBe NoAck
   }
 }

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
@@ -25,7 +25,7 @@ import configs.syntax._
 import hydra.common.logging.LoggingAdapter
 import hydra.core.http.HydraDirectives
 import hydra.core.ingest.{CorrelationIdBuilder, RequestParams}
-import hydra.core.marshallers.HydraJsonSupport
+import hydra.core.marshallers.{GenericError, HydraJsonSupport}
 import hydra.core.protocol.InitiateHttpRequest
 import hydra.ingest.bootstrap.HydraIngestorRegistryClient
 import hydra.ingest.services.IngestionHandlerGateway
@@ -82,7 +82,7 @@ class IngestionEndpoint(implicit val system: ActorSystem, implicit val e: Execut
   }
 
   private def exceptionHandler = ExceptionHandler {
-    case e: IllegalArgumentException => complete(400, e.getMessage)
+    case e: IllegalArgumentException => complete(400, GenericError(400, e.getMessage))
   }
 }
 

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
@@ -18,7 +18,7 @@ package hydra.ingest.http
 
 import akka.actor._
 import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.server.{Rejection, Route}
+import akka.http.scaladsl.server.{ExceptionHandler, Rejection, Route}
 import akka.stream.ActorMaterializer
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import configs.syntax._
@@ -55,11 +55,13 @@ class IngestionEndpoint(implicit val system: ActorSystem, implicit val e: Execut
   override val route: Route =
     pathPrefix("ingest") {
       pathEndOrSingleSlash {
-        post {
-          requestEntityPresent {
-            publishRequest
-          }
-        } ~ deleteRequest
+        handleExceptions(exceptionHandler) {
+          post {
+            requestEntityPresent {
+              publishRequest
+            }
+          } ~ deleteRequest
+        }
       }
     }
 
@@ -77,6 +79,10 @@ class IngestionEndpoint(implicit val system: ActorSystem, implicit val e: Execut
         }
       }
     }
+  }
+
+  private def exceptionHandler = ExceptionHandler {
+    case e: IllegalArgumentException => complete(400, e.getMessage)
   }
 }
 

--- a/ingest/src/test/scala/hydra/ingest/http/HttpRequestFactorySpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/HttpRequestFactorySpec.scala
@@ -44,6 +44,17 @@ class HttpRequestFactorySpec extends TestKit(ActorSystem()) with Matchers with F
       }
     }
 
+    it("errors out if an ack strategy that doesn't exist is specified") {
+      implicit val mat = ActorMaterializer()
+      val httpRequest = HttpRequest(
+        HttpMethods.POST,
+        uri = "/test",
+        entity = HttpEntity.Empty,
+        headers = Seq(RawHeader(RequestParams.HYDRA_ACK_STRATEGY, "invalid")))
+      val req = new HttpRequestFactory().createRequest("123", httpRequest)
+      whenReady(req.failed)(_ shouldBe an[IllegalArgumentException])
+    }
+
     it("builds a DELETE request") {
       implicit val mat = ActorMaterializer()
       val httpRequest = HttpRequest(

--- a/ingest/src/test/scala/hydra/ingest/http/IngestEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestEndpointSpec.scala
@@ -49,6 +49,7 @@ class IngestEndpointSpec extends Matchers with WordSpecLike with ScalatestRouteT
       }
     }
 
+
     "rejects empty requests" in {
       Post("/ingest") ~> ingestRoute ~> check {
         rejection shouldEqual RequestEntityExpectedRejection
@@ -73,6 +74,15 @@ class IngestEndpointSpec extends Matchers with WordSpecLike with ScalatestRouteT
       val request = Post("/ingest", "payload").withHeaders(ingestor)
       request ~> ingestRoute ~> check {
         status shouldBe StatusCodes.OK
+      }
+    }
+
+    "rejects a request with an invalid ack strategy" in {
+      val ingestor = RawHeader(RequestParams.HYDRA_INGESTOR_PARAM, "tester")
+      val request = Post("/ingest", "payload").withHeaders(ingestor
+        , RawHeader(RequestParams.HYDRA_ACK_STRATEGY, "invalid"))
+      request ~> ingestRoute ~> check {
+        status shouldBe StatusCodes.BadRequest
       }
     }
 

--- a/ingest/src/test/scala/hydra/ingest/http/IngestEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestEndpointSpec.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.{TestActorRef, TestKit}
 import hydra.common.util.ActorUtils
 import hydra.core.ingest.RequestParams
+import hydra.core.marshallers.GenericError
 import hydra.ingest.IngestorInfo
 import hydra.ingest.services.IngestorRegistry.{FindAll, FindByName, LookupResult}
 import hydra.ingest.test.TestIngestor
@@ -19,7 +20,10 @@ import scala.concurrent.duration._
 /**
   * Created by alexsilva on 5/12/17.
   */
-class IngestEndpointSpec extends Matchers with WordSpecLike with ScalatestRouteTest {
+class IngestEndpointSpec extends Matchers
+  with WordSpecLike
+  with ScalatestRouteTest
+  with HydraIngestJsonSupport {
 
   private implicit val timeout = RouteTestTimeout(10.seconds)
   val probe = system.actorOf(Props[TestIngestor])
@@ -83,6 +87,7 @@ class IngestEndpointSpec extends Matchers with WordSpecLike with ScalatestRouteT
         , RawHeader(RequestParams.HYDRA_ACK_STRATEGY, "invalid"))
       request ~> ingestRoute ~> check {
         status shouldBe StatusCodes.BadRequest
+        entityAs[GenericError].status shouldBe 400
       }
     }
 

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -68,13 +68,16 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
         wsClient.sendMessage("-c SET hydra-kafka-topic = test.Topic")
         wsClient.expectMessage("""{"status":200,"message":"OK[HYDRA-KAFKA-TOPIC=test.Topic]"}""")
         wsClient.sendMessage("-c SET hydra-ack = explicit")
-        wsClient.expectMessage("""{"status":200,"message":"OK[HYDRA-ACK=explicit]"}""")
+        wsClient.expectMessage("""{"status":400,"message":"BAD REQUEST[hydra-ack=explicit] is not a valid ack strategy."}""")
+
+        wsClient.sendMessage("-c SET hydra-ack = replicated")
+        wsClient.expectMessage("""{"status":200,"message":"OK[hydra-ack=replicated]"}""")
 
         wsClient.sendMessage("-c WHAT")
         wsClient.expectMessage("""{"status":400,"message":"BAD_REQUEST:Not a valid message. Use 'HELP' for help."}""")
 
         wsClient.sendMessage("-c SET")
-        wsClient.expectMessage("""{"status":200,"message":"HYDRA-KAFKA-TOPIC -> test.Topic;HYDRA-ACK -> explicit"}""")
+        wsClient.expectMessage("""{"status":200,"message":"HYDRA-KAFKA-TOPIC -> test.Topic;hydra-ack -> Replicated"}""")
 
         wsClient.sendMessage("-c HELP")
         wsClient.expectMessage("""{"status":200,"message":"Set metadata: --set (name)=(value)"}""")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,4 @@
 
-import java.sql.DriverManager
-
 import sbt.{ExclusionRule, _}
 
 
@@ -33,7 +31,7 @@ object Dependencies {
   val hikariCPVersion = "2.6.2"
   val jacksonVersion = "2.8.4"
   val opRabbitVersion = "2.0.0"
-  val constructRVersion = "0.18.1"
+  val constructRVersion = "0.19.0"
   val akkaHTTPCorsVersion = "0.2.2"
 
   val akkaKryoVersion = "0.5.2"


### PR DESCRIPTION
Currently, our default Ack strategy is NoAck.  In other words, if no hydra-ack metadata is specified, that will be the strategy we will use for the request.  However, if a request contains an invalid ack strategy header (such as "blah"), we silently set the ack strategy to NoAck as well without letting the requestor know they specified an invalid strategy.

This PR fixes that; if an invalid ack strategy header is present in the request and we cannot match it to a valid strategy, the endpoint will return a 400, Bad Request with the appropriate error message. 