### PR TITLE
Remove the coercion of a "null" string to a null value when using Avr…

### DIFF
--- a/sql/src/main/scala/hydra/sql/AvroValueSetter.scala
+++ b/sql/src/main/scala/hydra/sql/AvroValueSetter.scala
@@ -66,7 +66,7 @@ private[sql] class AvroValueSetter(schema: SchemaWrapper, dialect: JdbcDialect) 
             new Timestamp(new ISODateConverter()
               .fromCharSequence(value.toString, schema, IsoDate).toInstant.toEpochMilli))
         case Schema.Type.STRING =>
-          pstmt.setString(idx, if (value == "null" || value.toString == "null") null else value.toString)
+          pstmt.setString(idx, value.toString)
         case Schema.Type.BOOLEAN =>
           pstmt.setBoolean(idx, value.asInstanceOf[Boolean])
         case Schema.Type.DOUBLE =>


### PR DESCRIPTION
…oValueSetter to upsert records.  This was causing primary keys to break when the payload was "null".