### PR TITLE
Hydra key Feature Improvement

### DIFF
--- a/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
+++ b/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
@@ -1,7 +1,7 @@
 package hydra.avro.util
 
 import org.apache.avro.Schema
-import org.apache.avro.Schema.Field
+import org.apache.avro.Schema.{Field, Type}
 
 import scala.collection.mutable
 import scala.util.Try
@@ -33,10 +33,24 @@ case class SchemaWrapper(schema: Schema, primaryKeys: Seq[String]) {
           s"Please revise your request."
         throw new IllegalArgumentException(err)
       }
+
+      val unionMap = primaryKeys.map(schema.getField)
+        .map(f => f.name() -> isNullableUnion(f.schema())).filter(_._2).toMap
+      
+      if (!unionMap.isEmpty) {
+        val err = s"The field(s) '${unionMap.keys.mkString(",")}' were specified as " +
+          "primary keys, but they are nullable.  This is currently not supported."
+        throw new IllegalArgumentException(err)
+      }
+
     }
   }
 
   def getFields: mutable.Buffer[Field] = schema.getFields.asScala
+
+  private def isNullableUnion(schema: Schema): Boolean =
+    schema.getType == Type.UNION && schema.getTypes.size == 2 && schema.getTypes()
+      .contains(Schema.create(Type.NULL))
 
   def getName: String = schema.getName
 }

--- a/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
+++ b/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
@@ -36,7 +36,7 @@ case class SchemaWrapper(schema: Schema, primaryKeys: Seq[String]) {
 
       val unionMap = primaryKeys.map(schema.getField)
         .map(f => f.name() -> isNullableUnion(f.schema())).filter(_._2).toMap
-      
+
       if (!unionMap.isEmpty) {
         val err = s"The field(s) '${unionMap.keys.mkString(",")}' were specified as " +
           "primary keys, but they are nullable.  This is currently not supported."

--- a/avro/src/test/scala/hydra/avro/util/SchemaWrapperSpec.scala
+++ b/avro/src/test/scala/hydra/avro/util/SchemaWrapperSpec.scala
@@ -101,7 +101,7 @@ class SchemaWrapperSpec extends Matchers with FlatSpecLike {
         |		},
         |		{
         |			"name": "username",
-        |			"type": ["null", "string"]
+        |			"type": "string"
         |		}
         |	]
         |}""".stripMargin
@@ -109,6 +109,34 @@ class SchemaWrapperSpec extends Matchers with FlatSpecLike {
     val avro = new Schema.Parser().parse(schema)
 
     SchemaWrapper.from(avro).validate().get
+
+  }
+
+  it should "validate primary key fields are not nullable" in {
+    val schema =
+      """
+        |{
+        |	"type": "record",
+        |	"name": "User",
+        |	"namespace": "hydra",
+        | "hydra.key": "username",
+        |	"fields": [{
+        |			"name": "id",
+        |			"type": "int",
+        |			"doc": "doc"
+        |		},
+        |		{
+        |			"name": "username",
+        |			"type": ["null", "string"]
+        |		}
+        |	]
+        |}""".stripMargin
+
+    val avro = new Schema.Parser().parse(schema)
+
+    intercept[IllegalArgumentException] {
+      SchemaWrapper.from(avro).validate().get
+    }
 
   }
 

--- a/kafka/src/main/scala/hydra/kafka/producer/AvroRecordFactory.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/AvroRecordFactory.scala
@@ -31,8 +31,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
- * Created by alexsilva on 1/11/17.
- */
+  * Created by alexsilva on 1/11/17.
+  */
 class AvroRecordFactory(schemaResourceLoader: ActorRef)
   extends KafkaRecordFactory[String, GenericRecord] with ConfigSupport {
 
@@ -44,7 +44,7 @@ class AvroRecordFactory(schemaResourceLoader: ActorRef)
       (topic, subject) <- Future.fromTry(getTopicAndSchemaSubject(request))
       schemaResource <- (schemaResourceLoader ? FetchSchemaRequest(subject)).mapTo[FetchSchemaResponse].map(_.schemaResource)
       record <- convert(schemaResource, request)
-    } yield AvroRecord(topic, schemaResource.schema, getKey(request), record)
+    } yield AvroRecord(topic, schemaResource.schema, getKey(request, record), record)
   }
 
   private def convert(schemaResource: SchemaResource, request: HydraRequest)(implicit ec: ExecutionContext): Future[GenericRecord] = {

--- a/kafka/src/main/scala/hydra/kafka/producer/JsonRecordFactory.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/JsonRecordFactory.scala
@@ -33,7 +33,7 @@ object JsonRecordFactory extends KafkaRecordFactory[String, JsonNode] {
     for {
       topic <- Future.fromTry(getTopic(request))
       payload <- parseJson(request.payload)
-    } yield JsonRecord(topic, getKey(request), payload)
+    } yield JsonRecord(topic, getKey(request, payload), payload)
 
   }
 

--- a/kafka/src/main/scala/hydra/kafka/producer/KafkaRecordFactory.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/KafkaRecordFactory.scala
@@ -1,5 +1,6 @@
 package hydra.kafka.producer
 
+import com.fasterxml.jackson.databind.JsonNode
 import hydra.avro.util.SchemaWrapper
 import hydra.core.ingest.RequestParams._
 import hydra.core.ingest.{HydraRequest, RequestParams}
@@ -59,9 +60,16 @@ object KafkaRecordFactory {
 
   object RecordKeyExtractor {
 
-    implicit object JsonRecordKeyExtractor extends RecordKeyExtractor[String, String] {
+    implicit object StringRecordKeyExtractor extends RecordKeyExtractor[String, String] {
       override def extractKey(request: HydraRequest, record: String): Option[String] = {
         request.metadataValue(HYDRA_RECORD_KEY_PARAM).map(key => JsonPathKeys.getKey(key, record))
+      }
+    }
+
+    implicit object JsonRecordKeyExtractor extends RecordKeyExtractor[String, JsonNode] {
+      override def extractKey(request: HydraRequest, record: JsonNode): Option[String] = {
+        request.metadataValue(HYDRA_RECORD_KEY_PARAM)
+          .map(key => JsonPathKeys.getKey(key, record.toString))
       }
     }
 

--- a/kafka/src/main/scala/hydra/kafka/producer/StringRecordFactory.scala
+++ b/kafka/src/main/scala/hydra/kafka/producer/StringRecordFactory.scala
@@ -28,7 +28,7 @@ object StringRecordFactory extends KafkaRecordFactory[String, String] {
   override def build(request: HydraRequest)(implicit ex: ExecutionContext) = {
     for {
       topic <- Future.fromTry(getTopic(request))
-    } yield StringRecord(topic, getKey(request), request.payload)
+    } yield StringRecord(topic, getKey(request, request.payload), request.payload)
   }
 }
 

--- a/kafka/src/test/scala/hydra/kafka/producer/DeleteTombstoneRecordFactorySpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/DeleteTombstoneRecordFactorySpec.scala
@@ -44,12 +44,12 @@ class DeleteTombstoneRecordFactorySpec extends Matchers
     }
 
     it("builds a delete record") {
-      val request = HydraRequest("123", """{"name":"test"}""")
-        .withMetadata(HYDRA_RECORD_KEY_PARAM -> "{$.name}")
+      val request = HydraRequest("123", null)
+        .withMetadata(HYDRA_RECORD_KEY_PARAM -> "key")
         .withMetadata(HYDRA_KAFKA_TOPIC_PARAM -> "test-topic")
       whenReady(DeleteTombstoneRecordFactory.build(request)) { rec =>
         rec.destination shouldBe "test-topic"
-        rec.key shouldBe Some("test")
+        rec.key shouldBe Some("key")
         rec.formatName shouldBe "string"
         Option(rec.payload).isDefined shouldBe false
       }

--- a/kafka/src/test/scala/hydra/kafka/producer/JsonRecordKeyExtractorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/JsonRecordKeyExtractorSpec.scala
@@ -13,7 +13,7 @@ class JsonRecordKeyExtractorSpec extends Matchers with FlatSpecLike {
     val json = """{"name":"hydra","rank":1}"""
     val node = mapper.reader().readTree(json)
     val request = ingest.HydraRequest("corr", node.asText())
-    JsonRecordKeyExtractor.extractKey(request, node) shouldBe None
+    JsonRecordKeyExtractor.extractKeyValue(request, node) shouldBe None
   }
 
   it should "return a key" in {
@@ -21,6 +21,6 @@ class JsonRecordKeyExtractorSpec extends Matchers with FlatSpecLike {
     val node = mapper.reader().readTree(json)
     val request = ingest.HydraRequest("corr", node.asText())
       .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "{$.name}")
-    JsonRecordKeyExtractor.extractKey(request, node) shouldBe Some("hydra")
+    JsonRecordKeyExtractor.extractKeyValue(request, node) shouldBe Some("hydra")
   }
 }

--- a/kafka/src/test/scala/hydra/kafka/producer/JsonRecordKeyExtractorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/JsonRecordKeyExtractorSpec.scala
@@ -1,0 +1,26 @@
+package hydra.kafka.producer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import hydra.core.ingest
+import hydra.core.ingest.RequestParams
+import hydra.kafka.producer.KafkaRecordFactory.RecordKeyExtractor.JsonRecordKeyExtractor
+import org.scalatest.{FlatSpecLike, Matchers}
+
+class JsonRecordKeyExtractorSpec extends Matchers with FlatSpecLike {
+  val mapper = new ObjectMapper()
+
+  "The JsonRecordKeyExtractor" should "return none when no key is present" in {
+    val json = """{"name":"hydra","rank":1}"""
+    val node = mapper.reader().readTree(json)
+    val request = ingest.HydraRequest("corr", node.asText())
+    JsonRecordKeyExtractor.extractKey(request, node) shouldBe None
+  }
+
+  it should "return a key" in {
+    val json = """{"name":"hydra","rank":1}"""
+    val node = mapper.reader().readTree(json)
+    val request = ingest.HydraRequest("corr", node.asText())
+      .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "{$.name}")
+    JsonRecordKeyExtractor.extractKey(request, node) shouldBe Some("hydra")
+  }
+}

--- a/kafka/src/test/scala/hydra/kafka/producer/SchemaKeyExtractorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/SchemaKeyExtractorSpec.scala
@@ -1,0 +1,174 @@
+package hydra.kafka.producer
+
+import com.pluralsight.hydra.avro.JsonConverter
+import hydra.core.ingest.{HydraRequest, RequestParams}
+import hydra.kafka.producer.KafkaRecordFactory.RecordKeyExtractor.SchemaKeyExtractor
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+import org.scalatest.{FlatSpecLike, Matchers}
+
+class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
+
+  private def buildRecord(schemaStr: String, payload: String) = {
+    val schema = new Schema.Parser().parse(schemaStr)
+    new JsonConverter[GenericRecord](schema).convert(payload)
+  }
+
+  "The SchemaKeyExtractor" should "return none when no key is present" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+    SchemaKeyExtractor.extractKey(req, record) shouldBe None
+  }
+
+  it should "return a key when one is in the request" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+      .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "theKey")
+    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("theKey")
+  }
+
+  it should "return the key defined by 'hydra.key'" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "hydra.key":"name",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("hydra")
+  }
+
+  it should "return the request when both hydra-record-key and hydra.key are present" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "hydra.key":"name",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+      .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "theKey")
+    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("theKey")
+  }
+
+  it should "error when trying to use hydra.key for a non-existent key" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "hydra.key":"unknownField",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+    intercept[IllegalArgumentException] {
+      SchemaKeyExtractor.extractKey(req, record) shouldBe Some("1")
+    }
+  }
+
+  it should "return composite keys" in {
+    val record = buildRecord(
+      """
+        |{
+        |  "namespace": "hydra.test",
+        |  "type": "record",
+        |  "name": "Tester",
+        |  "hydra.key":"name,rank",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "rank",
+        |      "type": "int"
+        |    }
+        |  ]
+        |}
+      """.stripMargin,
+      """{"name":"hydra","rank":1}""")
+
+    val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
+    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("hydra|1")
+  }
+}

--- a/kafka/src/test/scala/hydra/kafka/producer/SchemaKeyExtractorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/producer/SchemaKeyExtractorSpec.scala
@@ -36,7 +36,7 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
       """{"name":"hydra","rank":1}""")
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
-    SchemaKeyExtractor.extractKey(req, record) shouldBe None
+    SchemaKeyExtractor.extractKeyValue(req, record) shouldBe None
   }
 
   it should "return a key when one is in the request" in {
@@ -62,7 +62,7 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
       .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "theKey")
-    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("theKey")
+    SchemaKeyExtractor.extractKeyValue(req, record) shouldBe Some("theKey")
   }
 
   it should "return the key defined by 'hydra.key'" in {
@@ -88,7 +88,7 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
       """{"name":"hydra","rank":1}""")
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
-    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("hydra")
+    SchemaKeyExtractor.extractKeyValue(req, record) shouldBe Some("hydra")
   }
 
   it should "return the request when both hydra-record-key and hydra.key are present" in {
@@ -115,7 +115,7 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
       .withMetadata(RequestParams.HYDRA_RECORD_KEY_PARAM -> "theKey")
-    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("theKey")
+    SchemaKeyExtractor.extractKeyValue(req, record) shouldBe Some("theKey")
   }
 
   it should "error when trying to use hydra.key for a non-existent key" in {
@@ -142,7 +142,7 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
     intercept[IllegalArgumentException] {
-      SchemaKeyExtractor.extractKey(req, record) shouldBe Some("1")
+      SchemaKeyExtractor.extractKeyValue(req, record) shouldBe Some("1")
     }
   }
 
@@ -169,6 +169,6 @@ class SchemaKeyExtractorSpec extends Matchers with FlatSpecLike {
       """{"name":"hydra","rank":1}""")
 
     val req = HydraRequest("123", """{"name":"hydra","rank":1}""")
-    SchemaKeyExtractor.extractKey(req, record) shouldBe Some("hydra|1")
+    SchemaKeyExtractor.extractKeyValue(req, record) shouldBe Some("hydra|1")
   }
 }

--- a/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
@@ -45,7 +45,6 @@ class JdbcRecordWriter(val settings: JdbcWriterSettings,
   import JdbcRecordWriter._
 
   logger.debug("Initializing JdbcRecordWriter")
-
   private val batchSize = settings.batchSize
 
   private val syntax = settings.dbSyntax

--- a/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
@@ -45,7 +45,7 @@ class JdbcRecordWriter(val settings: JdbcWriterSettings,
   import JdbcRecordWriter._
 
   logger.debug("Initializing JdbcRecordWriter")
-  
+
   private val batchSize = settings.batchSize
 
   private val syntax = settings.dbSyntax

--- a/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcRecordWriter.scala
@@ -45,6 +45,7 @@ class JdbcRecordWriter(val settings: JdbcWriterSettings,
   import JdbcRecordWriter._
 
   logger.debug("Initializing JdbcRecordWriter")
+  
   private val batchSize = settings.batchSize
 
   private val syntax = settings.dbSyntax


### PR DESCRIPTION
This PR adds the capability of retrieving primary keys based on the `hydra.key` schema property.  Previously, this property was ignored during ingestion.

With the proposed changes, requests no longer have to specify a `hydra-record-key` param for ingest if the schema being used has that property defined.

To keep the current behavior unchanged, if a request comes in with the `hydra-record-key` header, we'll honor that value even if the schema has the `hydra.key` property or not.