### PR TITLE
Fixes Postgres Upsert for version 10.  More info can be found here: h…

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -22,6 +22,8 @@ consul { //only relevant if using akka discovery consul
   service { //the name of the service to be registered in consul
     id = hydra
     id = ${?CONSUL_SERVICE_ID}
+    name = hydra
+    name = ${?CONSUL_SERVICE_NAME}
     check { //the check to be registed as part of the service in consul. Used to call the /health endpoint.
       host = localhost
       host = ${?HOST_IPV4_ADDRESS}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -142,12 +142,16 @@ object Dependencies {
     val h2db = "com.h2database" % "h2" % "1.4.196" % "test"
 
     val embeddedConsul = "com.pszymczyk.consul" % "embedded-consul" % "1.1.1" % "test"
+
+    val embeddedPostgres = "com.opentable.components" % "otj-pg-embedded" % "0.12.0" % "test"
+
   }
 
   import Compile._
   import Test._
 
-  val testDeps = Seq(scalaTest, junit, scalaMock, easyMock,embeddedConsul) ++ powerMock ++ akkaTest
+  val testDeps = Seq(scalaTest, junit, scalaMock, easyMock, embeddedConsul, embeddedPostgres) ++
+    powerMock ++ akkaTest
 
   val baseDeps = akka ++ logging ++ Seq(scalaz, scalaConfigs, avro, spring) ++ joda ++ testDeps
 

--- a/sql/src/main/scala/hydra/sql/PostgresDialect.scala
+++ b/sql/src/main/scala/hydra/sql/PostgresDialect.scala
@@ -78,7 +78,7 @@ private[sql] object PostgresDialect extends JdbcDialect {
     val sql =
       s"""insert into $table ($columns) values (${placeholders.mkString(",")})
          |on conflict (${idFields.map(formatColName).mkString(",")})
-         |do update set ($updateColumns) = (${updatePlaceholders.mkString(",")})
+         |do update set ($updateColumns) = ROW (${updatePlaceholders.mkString(",")})
          |where $whereClause;""".stripMargin
 
     sql

--- a/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
@@ -130,7 +130,7 @@ class AggregatedDialectSpec extends Matchers with FunSpecLike {
       val upsert =
         """insert into table ("id","username","active") values (?,?,?)
           |on conflict ("id")
-          |do update set ("username","active") = (?,?)
+          |do update set ("username","active") = ROW (?,?)
           |where table."id"=?;""".stripMargin
       dialect.buildUpsert("table", schema, UnderscoreSyntax) shouldBe upsert
     }

--- a/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
+++ b/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
@@ -402,7 +402,7 @@ class JdbcUtilsSpec extends Matchers
       JdbcUtils.dropTable(provider.getConnection(), "drop_test")
       intercept[JdbcSQLException] {
         TryWith(provider.getConnection().createStatement()) { stmt =>
-          stmt.executeUpdate("""insert into hydra_drop values(1,'test')""") shouldBe 1
+          stmt.executeUpdate("""insert into drop_test values(1,'test')""") shouldBe 1
         }.get
       }
     }

--- a/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
@@ -230,7 +230,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id","username","address") values (?,?,to_json(?::json))
           |on conflict ("id")
-          |do update set ("username","address") = (?,to_json(?::json))
+          |do update set ("username","address") = ROW (?,to_json(?::json))
           |where table."id"=?;""".stripMargin
 
       stmt shouldBe expected
@@ -269,7 +269,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id1","id2","username") values (?,?,?)
           |on conflict ("id1","id2")
-          |do update set ("username") = (?)
+          |do update set ("username") = ROW (?)
           |where table."id1"=? and table."id2"=?;""".stripMargin
 
       stmt shouldBe expected
@@ -415,7 +415,6 @@ class PostgresDialectSpec extends Matchers
     val schema = new Schema.Parser().parse(schemaR)
     val field = schema.getField("authors")
     getJdbcType(field.schema(), PostgresDialect).databaseTypeDefinition shouldBe "JSON" //the conversion is made by postgres
-    println(PostgresDialect.insertStatement("json_test", SchemaWrapper.from(schema), UnderscoreSyntax))
   }
 
   it("returns the correct array type") {

--- a/sql/src/test/scala/hydra/sql/PostgresUpsertSpec.scala
+++ b/sql/src/test/scala/hydra/sql/PostgresUpsertSpec.scala
@@ -1,0 +1,102 @@
+package hydra.sql
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres
+import hydra.avro.util.SchemaWrapper
+import hydra.common.util.TryWith
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecordBuilder
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+class PostgresUpsertSpec extends Matchers with FlatSpecLike with BeforeAndAfterAll {
+
+  lazy val pg = EmbeddedPostgres.start()
+
+  lazy val pgDb = pg.getPostgresDatabase()
+
+
+  val compositePKSchema = SchemaWrapper.from(new Schema.Parser().parse(
+    """
+      |{
+      |	"type": "record",
+      |	"name": "CompositeKeyUser",
+      | "hydra.key":"id,username",
+      |	"namespace": "hydra",
+      |	"fields": [{
+      |			"name": "id",
+      |			"type": "int"
+      |		},
+      |		{
+      |			"name": "username",
+      |			"type": "string"
+      |		},
+      |  {
+      |			"name": "rank",
+      |			"type": "int"
+      |		}
+      |	]
+      |}
+    """.stripMargin))
+
+  val schema = SchemaWrapper.from(new Schema.Parser().parse(
+    """
+      |{
+      |	"type": "record",
+      |	"name": "SingleKeyUser",
+      | "hydra.key":"id",
+      |	"namespace": "hydra",
+      |	"fields": [{
+      |			"name": "id",
+      |			"type": "int"
+      |		},
+      |		{
+      |			"name": "username",
+      |			"type": "string"
+      |		},
+      |  {
+      |			"name": "rank",
+      |			"type": "int"
+      |		}
+      |	]
+      |}
+    """.stripMargin))
+
+  override def beforeAll = {
+    TryWith(pgDb.getConnection("postgres", "")) { conn =>
+      JdbcUtils.createTable(compositePKSchema, PostgresDialect, "test_composite", "", UnderscoreSyntax, conn)
+      JdbcUtils.createTable(schema, PostgresDialect, "test_single", "", UnderscoreSyntax, conn)
+    }.get
+  }
+
+  override def afterAll = {
+    TryWith(pgDb.getConnection("postgres", "")) { conn =>
+      conn.prepareStatement("drop table test_composite")
+      conn.prepareStatement("drop table test_single")
+    }
+    pg.close()
+  }
+
+  "The Postgres dialect" should "create valid upsert statements for composite keys" in {
+    TryWith(pgDb.getConnection("postgres", "")) { conn =>
+      val sql = PostgresDialect.buildUpsert("test_composite", compositePKSchema, UnderscoreSyntax)
+      val stmt = conn.prepareStatement(sql)
+      println(sql)
+      val rec = new GenericRecordBuilder(compositePKSchema.schema).set("id", 1)
+        .set("username", "alex").set("rank", 10).build
+      new AvroValueSetter(compositePKSchema, PostgresDialect).bind(rec, stmt)
+      stmt.executeUpdate() shouldBe 1
+    }.get
+  }
+
+  it should "create valid upsert statements for single primary keys" in {
+    TryWith(pgDb.getConnection("postgres", "")) { conn =>
+      val sql = PostgresDialect.buildUpsert("test_single", schema, UnderscoreSyntax)
+      val stmt = conn.prepareStatement(sql)
+      println(sql)
+      val rec = new GenericRecordBuilder(schema.schema).set("id", 1)
+        .set("username", "alex").set("rank", 10).build
+      new AvroValueSetter(schema, PostgresDialect).bind(rec, stmt)
+      stmt.executeUpdate() shouldBe 1
+    }.get
+  }
+
+}


### PR DESCRIPTION
Currently, the Postgres upsert syntax is broken for Postgres 10, as now values need to be included within the ROW function.

The fact that the previous
coding allowed you to do that was a mistake, because per the PG spec you really
need to supply a row value when you parenthesize the SET column list.
As of v10 it should work to write
UPDATE my_table SET (my_col) = ROW(some value).

This fixes this issues and adds extra tests to make sure the syntax works with both versions of Postgres.