### PR TITLE
Postgres dialect compat

### DIFF
--- a/sql/src/main/scala/hydra/sql/PostgresDialect.scala
+++ b/sql/src/main/scala/hydra/sql/PostgresDialect.scala
@@ -72,14 +72,12 @@ private[sql] object PostgresDialect extends JdbcDialect {
     val placeholders = parameterize(fields)
     val updateSchema = fields -- idFields
     val updateColumns = updateSchema.map(formatColName).mkString(",")
-    val updatePlaceholders = parameterize(updateSchema)
-    val whereClause = idFields.map(c => s"$table.${formatColName(c)}=?").mkString(" and ")
+    val excludedValues = updateSchema.map(formatColName).map(x => s"EXCLUDED."+x).mkString(",")
 
     val sql =
       s"""insert into $table ($columns) values (${placeholders.mkString(",")})
          |on conflict (${idFields.map(formatColName).mkString(",")})
-         |do update set ($updateColumns) = ROW (${updatePlaceholders.mkString(",")})
-         |where $whereClause;""".stripMargin
+         |do update set ($updateColumns) = (${excludedValues});""".stripMargin
 
     sql
 

--- a/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
@@ -130,7 +130,7 @@ class AggregatedDialectSpec extends Matchers with FunSpecLike {
       val upsert =
         """insert into table ("id","username","active") values (?,?,?)
           |on conflict ("id")
-          |do update set ("username","active") = (EXCLUDED."username",EXCLUDED."active");""".stripMargin
+          |do update set "username" = EXCLUDED."username","active" = EXCLUDED."active";""".stripMargin
       dialect.buildUpsert("table", schema, UnderscoreSyntax) shouldBe upsert
     }
 

--- a/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/AggregatedDialectSpec.scala
@@ -130,8 +130,7 @@ class AggregatedDialectSpec extends Matchers with FunSpecLike {
       val upsert =
         """insert into table ("id","username","active") values (?,?,?)
           |on conflict ("id")
-          |do update set ("username","active") = ROW (?,?)
-          |where table."id"=?;""".stripMargin
+          |do update set ("username","active") = (EXCLUDED."username",EXCLUDED."active");""".stripMargin
       dialect.buildUpsert("table", schema, UnderscoreSyntax) shouldBe upsert
     }
 

--- a/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
@@ -230,7 +230,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id","username","address") values (?,?,to_json(?::json))
           |on conflict ("id")
-          |do update set ("username","address") = (EXCLUDED."username",EXCLUDED."address");""".stripMargin
+          |do update set "username" = EXCLUDED."username","address" = EXCLUDED."address";""".stripMargin
 
       stmt shouldBe expected
     }
@@ -268,7 +268,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id1","id2","username") values (?,?,?)
           |on conflict ("id1","id2")
-          |do update set ("username") = (EXCLUDED."username");""".stripMargin
+          |do update set "username" = EXCLUDED."username";""".stripMargin
 
       stmt shouldBe expected
     }
@@ -331,7 +331,7 @@ class PostgresDialectSpec extends Matchers
       val avro = new Schema.Parser().parse(schema)
 
       PostgresDialect.upsertFields(avro) shouldBe Seq(avro.getField("id1"), avro.getField("id2"),
-        avro.getField("username"), avro.getField("username"), avro.getField("id1"), avro.getField("id2"))
+        avro.getField("username"))
     }
 
     it("Creates the correct alter table statements") {

--- a/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
+++ b/sql/src/test/scala/hydra/sql/PostgresDialectSpec.scala
@@ -230,8 +230,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id","username","address") values (?,?,to_json(?::json))
           |on conflict ("id")
-          |do update set ("username","address") = ROW (?,to_json(?::json))
-          |where table."id"=?;""".stripMargin
+          |do update set ("username","address") = (EXCLUDED."username",EXCLUDED."address");""".stripMargin
 
       stmt shouldBe expected
     }
@@ -269,8 +268,7 @@ class PostgresDialectSpec extends Matchers
       val expected =
         """insert into table ("id1","id2","username") values (?,?,?)
           |on conflict ("id1","id2")
-          |do update set ("username") = ROW (?)
-          |where table."id1"=? and table."id2"=?;""".stripMargin
+          |do update set ("username") = (EXCLUDED."username");""".stripMargin
 
       stmt shouldBe expected
     }


### PR DESCRIPTION
Example of output: ```insert into table ("id","username","address") values (?,?,to_json(?::json))
on conflict ("id")
do update set "username" = EXCLUDED."username","address" = EXCLUDED."address";```