### PR TITLE
Fixes primary key creation in JdbcUtils to use the table name and not…

### DIFF
--- a/sql/src/main/scala/hydra/sql/JdbcUtils.scala
+++ b/sql/src/main/scala/hydra/sql/JdbcUtils.scala
@@ -88,7 +88,7 @@ private[sql] object JdbcUtils {
                   createTableOptions: String,
                   dbSyntax: DbSyntax,
                   conn: Connection): Int = {
-    val strSchema = schemaString(schema, dialect, dbSyntax)
+    val strSchema = schemaString(schema, table, dialect, dbSyntax)
     val sql = s"CREATE TABLE $table ($strSchema) $createTableOptions"
     logger.debug(sql)
     val statement = conn.createStatement
@@ -140,7 +140,7 @@ private[sql] object JdbcUtils {
   }
 
 
-  def schemaString(schema: SchemaWrapper, dialect: JdbcDialect,
+  def schemaString(schema: SchemaWrapper, tableName:String, dialect: JdbcDialect,
                    dbSyntax: DbSyntax = NoOpSyntax): String = {
     val schemaStr = schema.getFields.map { field =>
       val name = dialect.quoteIdentifier(dbSyntax.format(field.name))
@@ -150,7 +150,7 @@ private[sql] object JdbcUtils {
     }
     val pkSeq = schema.primaryKeys
       .map(f => dialect.quoteIdentifier(dbSyntax.format(f)))
-    val pkStmt = if (!pkSeq.isEmpty) s",CONSTRAINT ${schema.getName}_PK PRIMARY KEY (${pkSeq.mkString(",")})" else ""
+    val pkStmt = if (!pkSeq.isEmpty) s""",CONSTRAINT "${tableName}_PK" PRIMARY KEY (${pkSeq.mkString(",")})""" else ""
     val ddl = s"${schemaStr.mkString(",")}${pkStmt}"
     ddl
   }

--- a/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
+++ b/sql/src/test/scala/hydra/sql/JdbcUtilsSpec.scala
@@ -295,7 +295,7 @@ class JdbcUtilsSpec extends Matchers
         "\"passwordHash\" BYTE NOT NULL,\"signupTimestamp\" TIMESTAMP NOT NULL,\"scoreLong\" BIGINT NOT NULL," +
         "\"signupDate\" DATE NOT NULL,\"justANumber\" INTEGER NOT NULL,\"testUnion\" TEXT "
 
-      JdbcUtils.schemaString(SchemaWrapper.from(avro), NoopDialect) shouldBe columns
+      JdbcUtils.schemaString(SchemaWrapper.from(avro), "User", NoopDialect) shouldBe columns
     }
 
     it("Generates the correct ddl statement") {
@@ -329,8 +329,8 @@ class JdbcUtilsSpec extends Matchers
 
       val avro = new Schema.Parser().parse(schema)
 
-      val stmt = JdbcUtils.schemaString(SchemaWrapper.from((avro)), PostgresDialect)
-      stmt shouldBe "\"id\" INTEGER NOT NULL,\"username\" TEXT NOT NULL,\"testEnum\" TEXT NOT NULL,CONSTRAINT User_PK PRIMARY KEY (\"id\")"
+      val stmt = JdbcUtils.schemaString(SchemaWrapper.from((avro)), "User", PostgresDialect)
+      stmt shouldBe "\"id\" INTEGER NOT NULL,\"username\" TEXT NOT NULL,\"testEnum\" TEXT NOT NULL,CONSTRAINT \"User_PK\" PRIMARY KEY (\"id\")"
     }
 
     it("Generates the correct ddl statement with composite primary  keys") {
@@ -367,9 +367,9 @@ class JdbcUtilsSpec extends Matchers
         """.stripMargin
 
       val avro = new Schema.Parser().parse(schema)
-      val stmt = JdbcUtils.schemaString(SchemaWrapper.from((avro)), PostgresDialect)
+      val stmt = JdbcUtils.schemaString(SchemaWrapper.from((avro)), "User", PostgresDialect)
       stmt shouldBe "\"id1\" INTEGER NOT NULL,\"id2\" INTEGER NOT NULL,\"username\" TEXT NOT NULL," +
-        "\"testEnum\" TEXT NOT NULL,CONSTRAINT User_PK PRIMARY KEY (\"id1\",\"id2\")"
+        "\"testEnum\" TEXT NOT NULL,CONSTRAINT \"User_PK\" PRIMARY KEY (\"id1\",\"id2\")"
     }
 
     it("Generates the correct table name from a versioned schema") {


### PR DESCRIPTION
… the schema name.  This was causing issues when a custom table name was being created, since the primary key wasn't being dropped.