### PR TITLE
fix-journal

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -131,6 +131,7 @@ akka {
       "hydra.core.transport.AckStrategy$Persisted$" = kryo
       "hydra.core.protocol.IngestorCompleted$" = kryo
       "hydra.core.protocol.IngestionError" = kryo
+      "hydra.core.transport.Transport$DestinationConfirmed" = kryo
       "scala.Option" = kryo
       "scala.Some" = kryo
       "scala.None" = kryo

--- a/core/src/main/scala/hydra/core/transport/Transport.scala
+++ b/core/src/main/scala/hydra/core/transport/Transport.scala
@@ -22,8 +22,8 @@ trait Transport extends PersistentActor
     case Confirm(deliveryId) =>
       if (deliveryId > 0) persistAsync(DestinationConfirmed(deliveryId))(updateState)
 
-    case TransportError(deliveryId) =>
-      if (deliveryId > 0) persistAsync(DestinationConfirmed(deliveryId))(updateState) //delete from journal (error)
+    case t@TransportError(_) =>
+      context.system.eventStream.publish(t)
   }
 
   final override def receiveCommand = baseCommand orElse transport


### PR DESCRIPTION
adds DestinationConfirmed object to kryo serializers and ensures ingest message TransportErrors do not wind up in confirmDelivery