### PR TITLE
Allows materialization jobs to override the hydra.key schema property…

### DIFF
--- a/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
+++ b/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
@@ -67,7 +67,7 @@ object SchemaWrapper {
     * @param primaryKeys A sequence where the values are field names to be used as primary keys.
     *                    This will override the `hydra.keys` schema property.
     *                    For streaming materialization jobs where no primary key is to be used,
-    *                    an empty sequence should be used.
+    *                    an empty sequence should be provided as this method's argument.
     * @return a SchemaWrapper instance
     */
   def from(schema: Schema, primaryKeys: Seq[String]): SchemaWrapper = {

--- a/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
+++ b/avro/src/main/scala/hydra/avro/util/SchemaWrapper.scala
@@ -61,8 +61,17 @@ object SchemaWrapper {
     SchemaWrapper(schema, schemaPKs(schema))
   }
 
+  /**
+    *
+    * @param schema The avro schema
+    * @param primaryKeys A sequence where the values are field names to be used as primary keys.
+    *                    This will override the `hydra.keys` schema property.
+    *                    For streaming materialization jobs where no primary key is to be used,
+    *                    an empty sequence should be used.
+    * @return a SchemaWrapper instance
+    */
   def from(schema: Schema, primaryKeys: Seq[String]): SchemaWrapper = {
-    SchemaWrapper(schema, if (primaryKeys.isEmpty) schemaPKs(schema) else primaryKeys)
+    SchemaWrapper(schema, primaryKeys)
   }
 
   private def schemaPKs(schema: Schema): Seq[String] = {

--- a/avro/src/test/scala/hydra/avro/util/SchemaWrapperSpec.scala
+++ b/avro/src/test/scala/hydra/avro/util/SchemaWrapperSpec.scala
@@ -223,7 +223,36 @@ class SchemaWrapperSpec extends Matchers with FlatSpecLike {
     val avro = new Schema.Parser().parse(schema)
 
     SchemaWrapper.from(avro).primaryKeys shouldBe Seq("id1", "id2")
+  }
 
+  it should "allow empty primary keys" in {
+    val schema =
+      """
+        |{
+        |	"type": "record",
+        |	"name": "User",
+        |	"namespace": "hydra",
+        | "hydra.key": "id1, id2",
+        |	"fields": [{
+        |			"name": "id1",
+        |			"type": "int",
+        |			"doc": "doc"
+        |		},
+        |  {
+        |			"name": "id2",
+        |			"type": "int",
+        |			"doc": "doc"
+        |		},
+        |		{
+        |			"name": "username",
+        |			"type": ["null", "string"]
+        |		}
+        |	]
+        |}""".stripMargin
+
+    val avro = new Schema.Parser().parse(schema)
+
+    SchemaWrapper.from(avro, Seq.empty).primaryKeys shouldBe Seq.empty
   }
 
 }


### PR DESCRIPTION
… to an empty string, so that primary keys can be "turned off" in replication jobs, allowing consumers to replay the entire topic history without any upserts.