### PR TITLE
Akka cluster requires at least two nodes in order to fully bootstrap …

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -60,6 +60,8 @@ akka {
     cluster.bootstrap {
       contact-point-discovery {
         service-name = "hydra"
+        required-contact-point-nr = 2
+        required-contact-point-nr = ${?AKKA_MANAGEMENT_CLUSTER_BOOTSTRAP_REQUIRED_CONTACT_POINT_NR}
       }
     }
     http {


### PR DESCRIPTION
…a cluster.  This is a problem in docker, since only one node is available.  This number is configured by a configuration property called "required-contact-point-nr" under "akka.management.cluster.bootstrap"  This PR adds an environment variable named "AKKA_MANAGEMENT_CLUSTER_BOOTSTRAP_REQUIRED_CONTACT_POINT_NR" so that we can override the default value of 2 on docker.