### PR TITLE
fixes issue where some non-existing kafka topics aren't created

### DIFF
--- a/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
+++ b/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
@@ -210,7 +210,7 @@ class TopicBootstrapActor(schemaRegistryActor: ActorRef,
 
     if(shouldCreateCompactedTopic(topicMetadataRequest)) {
       val compactedPrefix = bootstrapKafkaConfig.get[String]("compacted-topic-prefix").valueOrElse("_compacted.")
-      log.info(s"adding $compactedPrefix to creation...")
+      log.info(s"adding $compactedPrefix to creation of $topicName....")
       topicMap += (compactedPrefix+topicName -> compactedDetails)
     }
 

--- a/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
+++ b/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
@@ -214,9 +214,7 @@ class TopicBootstrapActor(schemaRegistryActor: ActorRef,
       topicMap += (compactedPrefix+topicName -> compactedDetails)
     }
 
-    val createMap = topicMap.filterNot(nameDetails => {
-      kafkaUtils.topicExists(nameDetails._1).get
-    })
+    val createMap = topicMap.filterNot(nameDetails => kafkaUtils.topicExists(nameDetails._1).get)
 
     kafkaUtils.createTopics(createMap, timeout = timeoutMillis)
       .map { r =>

--- a/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
@@ -459,11 +459,11 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
     }
   }
 
-  it should "create topics compacted topics that don't exist, but not error for topics that do exist" in {
+  it should "create compacted topics that don't exist, but not error for topics that do exist" in {
 
-    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
+    val mdRequest = buildTestRequest("testsbject51", "exp.dataplatform")
 
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test16")
 
     val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
       system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
@@ -473,12 +473,12 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
     val senderProbe = TestProbe()
 
-    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject5")
+    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject51")
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
 
     val expectedMessage = "message"
-    val consumeSubject = "_compacted.exp.dataplatform.testsbject5"
+    val consumeSubject = "_compacted.exp.dataplatform.testsbject51"
 
     //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
     publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
@@ -487,9 +487,9 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "create topics historical topics that don't exist, but not error for compacted topics that do exist" in {
 
-    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
+    val mdRequest = buildTestRequest("testsbject52", "exp.dataplatform")
 
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test337")
 
     val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
       system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
@@ -499,12 +499,12 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
     val senderProbe = TestProbe()
 
-    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject5")
+    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject52")
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
 
     val expectedMessage = "message"
-    val consumeSubject = "_compacted.exp.dataplatform.testsbject5"
+    val consumeSubject = "_compacted.exp.dataplatform.testsbject52"
 
     //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
     publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
@@ -514,9 +514,9 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "not error when topics already exist" in {
 
-    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
+    val mdRequest = buildTestRequest("testsbject67", "exp.dataplatform")
 
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12221")
 
     val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
       system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
@@ -526,13 +526,13 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
     val senderProbe = TestProbe()
 
-    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject5")
-    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject5")
+    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject67")
+    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject67")
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
 
     val expectedMessage = "message"
-    val consumeSubject = "_compacted.exp.dataplatform.testsbject5"
+    val consumeSubject = "_compacted.exp.dataplatform.testsbject67"
 
     //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
     publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())

--- a/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
@@ -110,32 +110,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   "A TopicBootstrapActor" should "process metadata and send an Ingest message to the kafka ingestor" in {
 
-    val mdRequest = """{
-                      |	"subject": "exp.dataplatform.testsubject1",
-                      |	"streamType": "Notification",
-                      | "derived": false,
-                      |	"dataClassification": "Public",
-                      |	"dataSourceOwner": "BARTON",
-                      |	"contact": "slackity slack dont talk back",
-                      |	"psDataLake": false,
-                      |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                      |	"notes": "here are some notes topkek",
-                      |	"schema": {
-                      |	  "namespace": "exp.assessment",
-                      |	  "name": "SkillAssessmentTopicsScored",
-                      |	  "type": "record",
-                      |	  "version": 1,
-                      |	  "fields": [
-                      |	    {
-                      |	      "name": "testField",
-                      |	      "type": "string"
-                      |	    }
-                      |	  ]
-                      |	}
-                      |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject1", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test1")
 
@@ -162,32 +137,8 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
   }
 
   it should "respond with the error that caused the failed actor state" in {
-    val mdRequest = """{
-                      |	"subject": "exp.dataplatform.testsubject2",
-                      |	"streamType": "Notification",
-                      | "derived": false,
-                      |	"dataClassification": "Public",
-                      |	"dataSourceOwner": "BARTON",
-                      |	"contact": "slackity slack dont talk back",
-                      |	"psDataLake": false,
-                      |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                      |	"notes": "here are some notes topkek",
-                      |	"schema": {
-                      |	  "namespace": "exp.assessment",
-                      |	  "name": "SkillAssessmentTopicsScored",
-                      |	  "type": "record",
-                      |	  "version": 1,
-                      |	  "fields": [
-                      |	    {
-                      |	      "name": "testField",
-                      |	      "type": "string"
-                      |	    }
-                      |	  ]
-                      |	}
-                      |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+
+    val mdRequest = buildTestRequest("testsbject2", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, _) = fixture("test2",
       schemaRegistryShouldFail = true)
@@ -210,32 +161,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "respond with the appropriate metadata failure message" in {
 
-    val mdRequest = """{
-                      |	"subject": "exp....",
-                      |	"streamType": "Notification",
-                      | "derived": false,
-                      |	"dataClassification": "Public",
-                      |	"dataSourceOwner": "BARTON",
-                      |	"contact": "slackity slack dont talk back",
-                      |	"psDataLake": false,
-                      |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                      |	"notes": "here are some notes topkek",
-                      |	"schema": {
-                      |	  "namespace": "exp.assessment",
-                      |	  "name": "SkillAssessmentTopicsScored",
-                      |	  "type": "record",
-                      |	  "version": 1,
-                      |	  "fields": [
-                      |	    {
-                      |	      "name": "testField",
-                      |	      "type": "string"
-                      |	    }
-                      |	  ]
-                      |	}
-                      |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("", "exp....")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test3")
 
@@ -256,32 +182,8 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
   }
 
   it should "respond with the appropriate failure when the KafkaIngestor returns an exception" in {
-    val mdRequest = """{
-                      |	"subject": "exp.dataplatform.testsubject4",
-                      |	"streamType": "Notification",
-                      | "derived": false,
-                      |	"dataClassification": "Public",
-                      |	"dataSourceOwner": "BARTON",
-                      |	"contact": "slackity slack dont talk back",
-                      |	"psDataLake": false,
-                      |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                      |	"notes": "here are some notes topkek",
-                      |	"schema": {
-                      |	  "namespace": "exp.assessment",
-                      |	  "name": "SkillAssessmentTopicsScored",
-                      |	  "type": "record",
-                      |	  "version": 1,
-                      |	  "fields": [
-                      |	    {
-                      |	      "name": "testField",
-                      |	      "type": "string"
-                      |	    }
-                      |	  ]
-                      |	}
-                      |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+
+    val mdRequest = buildTestRequest("testsbject4", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test4", kafkaShouldFail = true)
 
@@ -302,34 +204,8 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
   }
 
   it should "create the kafka topic" in {
-    val subject = "exp.dataplatform.testsubject5"
 
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "Notification",
-                       | "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test5")
 
@@ -359,45 +235,19 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
       case BootstrapSuccess(tm) =>
         tm.schemaId should be > 0
         tm.derived shouldBe false
-        tm.subject shouldBe subject
+        tm.subject shouldBe mdRequest.subject
     }
 
     val expectedMessage = "I'm expected!"
 
-    publishStringMessageToKafka(subject, expectedMessage)
+    publishStringMessageToKafka(mdRequest.subject, expectedMessage)
 
-    consumeFirstStringMessageFrom(subject) shouldEqual expectedMessage
+    consumeFirstStringMessageFrom(mdRequest.subject) shouldEqual expectedMessage
   }
 
   it should "return a BootstrapFailure for failures while creating the kafka topic" in {
-    val subject = "exp.dataplatform.testsubject6"
 
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "Notification",
-                       | "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject6", "exp.dataplatform")
 
     val testConfig = ConfigFactory.parseString(
       """
@@ -441,34 +291,8 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
   }
 
   it should "not fail due to a topic already existing" in {
-    val subject = "exp.dataplatform.testsubject7"
 
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "Notification",
-                       | "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject7", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test7")
 
@@ -498,7 +322,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
       case BootstrapSuccess(tm) =>
         tm.schemaId should be > 0
         tm.derived shouldBe false
-        tm.subject shouldBe subject
+        tm.subject shouldBe mdRequest.subject
     }
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
@@ -507,7 +331,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
       case BootstrapSuccess(tm) =>
         tm.schemaId should be > 0
         tm.derived shouldBe false
-        tm.subject shouldBe subject
+        tm.subject shouldBe mdRequest.subject
     }
   }
 
@@ -554,32 +378,8 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
   }
 
   it should "retry after a configurable interval when the schema registration fails" in {
-    val mdRequest = """{
-                      |	"subject": "exp.dataplatform.testsubject8",
-                      |	"streamType": "Notification",
-                      | "derived": false,
-                      |	"dataClassification": "Public",
-                      |	"dataSourceOwner": "BARTON",
-                      |	"contact": "slackity slack dont talk back",
-                      |	"psDataLake": false,
-                      |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                      |	"notes": "here are some notes topkek",
-                      |	"schema": {
-                      |	  "namespace": "exp.assessment",
-                      |	  "name": "SkillAssessmentTopicsScored",
-                      |	  "type": "record",
-                      |	  "version": 1,
-                      |	  "fields": [
-                      |	    {
-                      |	      "name": "testField",
-                      |	      "type": "string"
-                      |	    }
-                      |	  ]
-                      |	}
-                      |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+
+    val mdRequest = buildTestRequest("testsbject8", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, _) = fixture("test8",
       schemaRegistryShouldFail = true)
@@ -612,35 +412,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "create a compacted topic if a hydra key exists and the stream type is historic" in {
 
-      val subject = "exp.dataplatform.testsbject5"
-
-      val mdRequest = s"""{
-                         |	"subject": "$subject",
-                         |	"streamType": "History",
-                         |  "derived": false,
-                         |	"dataClassification": "Public",
-                         |	"dataSourceOwner": "BARTON",
-                         |	"contact": "slackity slack dont talk back",
-                         |	"psDataLake": false,
-                         |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                         |	"notes": "here are some notes topkek",
-                         |	"schema": {
-                         |	  "namespace": "exp.assessment",
-                         |	  "name": "SkillAssessmentTopicsScored",
-                         |    "hydra.key": "testField",
-                         |	  "type": "record",
-                         |	  "version": 1,
-                         |	  "fields": [
-                         |	    {
-                         |	      "name": "testField",
-                         |	      "type": "string"
-                         |	    }
-                         |	  ]
-                         |	}
-                         |}"""
-        .stripMargin
-        .parseJson
-        .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
 
       val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
 
@@ -664,34 +436,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "not create a compacted topic if hydra.key is not present" in {
 
-    val subject = "exp.dataplatform.testsbject6"
-
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "History",
-                       |  "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequestWithoutHydraKey("testsbject6", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test13")
 
@@ -716,35 +461,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "create topics compacted topics that don't exist, but not error for topics that do exist" in {
 
-    val subject = "exp.dataplatform.testsbject5"
-
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "History",
-                       |  "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |    "hydra.key": "testField",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
 
@@ -770,35 +487,7 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "create topics historical topics that don't exist, but not error for compacted topics that do exist" in {
 
-    val subject = "exp.dataplatform.testsbject5"
-
-    val mdRequest = s"""{
-                       |	"subject": "$subject",
-                       |	"streamType": "History",
-                       |  "derived": false,
-                       |	"dataClassification": "Public",
-                       |	"dataSourceOwner": "BARTON",
-                       |	"contact": "slackity slack dont talk back",
-                       |	"psDataLake": false,
-                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
-                       |	"notes": "here are some notes topkek",
-                       |	"schema": {
-                       |	  "namespace": "exp.assessment",
-                       |	  "name": "SkillAssessmentTopicsScored",
-                       |    "hydra.key": "testField",
-                       |	  "type": "record",
-                       |	  "version": 1,
-                       |	  "fields": [
-                       |	    {
-                       |	      "name": "testField",
-                       |	      "type": "string"
-                       |	    }
-                       |	  ]
-                       |	}
-                       |}"""
-      .stripMargin
-      .parseJson
-      .convertTo[TopicMetadataRequest]
+    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
 
     val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
 
@@ -825,10 +514,36 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
   it should "not error when topics already exist" in {
 
-    val subject = "exp.dataplatform.testsbject5"
+    val mdRequest = buildTestRequest("testsbject5", "exp.dataplatform")
+
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
+
+    val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
+      system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
+    ))
+
+    probe.expectMsgType[RegisterSchemaRequest]
+
+    val senderProbe = TestProbe()
+
+    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject5")
+    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject5")
+
+    bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
+
+    val expectedMessage = "message"
+    val consumeSubject = "_compacted.exp.dataplatform.testsbject5"
+
+    //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
+    publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
+    consumeFirstStringMessageFrom(consumeSubject) shouldEqual expectedMessage
+  }
+
+
+  def buildTestRequest(name: String, namespace: String): TopicMetadataRequest = {
 
     val mdRequest = s"""{
-                       |	"subject": "$subject",
+                       |	"subject": "${namespace + "." + name}",
                        |	"streamType": "History",
                        |  "derived": false,
                        |	"dataClassification": "Public",
@@ -854,29 +569,40 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
       .stripMargin
       .parseJson
       .convertTo[TopicMetadataRequest]
-
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test12")
-
-    val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
-      system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
-    ))
-
-    probe.expectMsgType[RegisterSchemaRequest]
-
-    val senderProbe = TestProbe()
-
-    EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject5")
-    EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject5")
-
-    bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
-
-    val expectedMessage = "message"
-    val consumeSubject = "_compacted.exp.dataplatform.testsbject5"
-
-    //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
-    publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
-    consumeFirstStringMessageFrom(consumeSubject) shouldEqual expectedMessage
+    mdRequest
   }
+
+  def buildTestRequestWithoutHydraKey(name: String, namespace: String): TopicMetadataRequest = {
+
+    val mdRequest = s"""{
+                       |	"subject": "${namespace + "." + name}",
+                       |	"streamType": "History",
+                       |  "derived": false,
+                       |	"dataClassification": "Public",
+                       |	"dataSourceOwner": "BARTON",
+                       |	"contact": "slackity slack dont talk back",
+                       |	"psDataLake": false,
+                       |	"additionalDocumentation": "akka://some/path/here.jpggifyo",
+                       |	"notes": "here are some notes topkek",
+                       |	"schema": {
+                       |	  "namespace": "exp.assessment",
+                       |	  "name": "SkillAssessmentTopicsScored",
+                       |	  "type": "record",
+                       |	  "version": 1,
+                       |	  "fields": [
+                       |	    {
+                       |	      "name": "testField",
+                       |	      "type": "string"
+                       |	    }
+                       |	  ]
+                       |	}
+                       |}"""
+      .stripMargin
+      .parseJson
+      .convertTo[TopicMetadataRequest]
+    mdRequest
+  }
+
 
 }
 

--- a/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
+++ b/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
@@ -463,16 +463,15 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
 
     val mdRequest = buildTestRequest("testsbject51", "exp.dataplatform")
 
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test16")
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test77")
 
     val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
-      system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
+      system.actorSelection("/user/kafka_ingestor_test77"), Props(new MockStreamsManagerActor())
     ))
 
     probe.expectMsgType[RegisterSchemaRequest]
 
     val senderProbe = TestProbe()
-
     EmbeddedKafka.createCustomTopic("exp.dataplatform.testsbject51")
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
@@ -483,32 +482,34 @@ class TopicBootstrapActorSpec extends TestKit(ActorSystem("topic-bootstrap-actor
     //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
     publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
     consumeFirstStringMessageFrom(consumeSubject) shouldEqual expectedMessage
+
+
   }
 
-  it should "create topics historical topics that don't exist, but not error for compacted topics that do exist" in {
+  it should "create historical topics that don't exist, but not error for compacted topics that do exist" in {
 
     val mdRequest = buildTestRequest("testsbject52", "exp.dataplatform")
 
-    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test337")
+    val (probe, schemaRegistryActor, kafkaIngestor) = fixture("test78")
 
     val bootstrapActor = system.actorOf(TopicBootstrapActor.props(schemaRegistryActor,
-      system.actorSelection("/user/kafka_ingestor_test12"), Props(new MockStreamsManagerActor())
+      system.actorSelection("/user/kafka_ingestor_test78"), Props(new MockStreamsManagerActor())
     ))
 
     probe.expectMsgType[RegisterSchemaRequest]
 
     val senderProbe = TestProbe()
-
     EmbeddedKafka.createCustomTopic("_compacted.exp.dataplatform.testsbject52")
 
     bootstrapActor.tell(InitiateTopicBootstrap(mdRequest), senderProbe.ref)
 
     val expectedMessage = "message"
-    val consumeSubject = "_compacted.exp.dataplatform.testsbject52"
+    val consumeSubject = "exp.dataplatform.testsbject52"
 
     //need to publish a KEY and VALUE here, otherwise kafka throws an exception for the compacted topic
     publishToKafka(consumeSubject, expectedMessage, expectedMessage)(config = embeddedKafkaConfig, new StringSerializer(), new StringSerializer())
     consumeFirstStringMessageFrom(consumeSubject) shouldEqual expectedMessage
+
   }
 
 


### PR DESCRIPTION
this change fixes the following:
the topicbootstrapactor won't falsely return a success (leaving the user to have assumed all topic creations succeed) if any topic creations fail.

we still combine both original and compacted topic creation into the same method.