### PR TITLE
Web Socket Streaming requests

### DIFF
--- a/ingest/src/main/resources/reference.conf
+++ b/ingest/src/main/resources/reference.conf
@@ -12,6 +12,8 @@ hydra {
     enabled = ${?INGEST_WEBSOCKET_ENABLED}
     max-frames = 50
     max-frames = ${?INGEST_WEBSOCKET_MAX_FRAMES}
+    stream-timeout = 10 seconds
+    stream-timeout = ${?INGEST_WEBSOCKET_STREAM_TIMEOUT}
   }
 }
 

--- a/ingest/src/main/resources/reference.conf
+++ b/ingest/src/main/resources/reference.conf
@@ -12,7 +12,7 @@ hydra {
     enabled = ${?INGEST_WEBSOCKET_ENABLED}
     max-frames = 50
     max-frames = ${?INGEST_WEBSOCKET_MAX_FRAMES}
-    stream-timeout = 10 seconds
+    stream-timeout = 5 seconds
     stream-timeout = ${?INGEST_WEBSOCKET_STREAM_TIMEOUT}
   }
 }

--- a/ingest/src/main/resources/reference.conf
+++ b/ingest/src/main/resources/reference.conf
@@ -3,11 +3,16 @@ akka {
 }
 
 hydra {
-  monitoring.prometheus.enable = false
-  monitoring.prometheus.enable = ${?MONITORING_PROMETHEUS_ENABLE}
-  ingest.websocket.enabled = true
-  ingest.websocket.enabled = ${?INGEST_WEBSOCKET_ENABLED}
-
+  monitoring.prometheus {
+    enable = false
+    enable = ${?MONITORING_PROMETHEUS_ENABLE}
+  }
+  ingest.websocket {
+    enabled = true
+    enabled = ${?INGEST_WEBSOCKET_ENABLED}
+    max-frames = 50
+    max-frames = ${?INGEST_WEBSOCKET_MAX_FRAMES}
+  }
 }
 
 kamon.prometheus {

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
@@ -22,7 +22,9 @@ import akka.http.scaladsl.model.ws.{Message, TextMessage}
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Flow
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
+import com.typesafe.config.{Config, ConfigFactory}
 import configs.syntax._
+import hydra.common.config.ConfigSupport
 import hydra.common.logging.LoggingAdapter
 import hydra.core.http.HydraDirectives
 import hydra.core.marshallers.GenericServiceResponse
@@ -44,7 +46,7 @@ class IngestionWebSocketEndpoint(implicit system: ActorSystem, implicit val e: E
 
   private val socketFactory = IngestSocketFactory.createSocket(system)
 
-  implicit val simpleOutgoingMessageFormat = jsonFormat2(SimpleOutgoingMessage)
+  implicit val simpleOutgoingMessageFormat: JsonFormat[SimpleOutgoingMessage] = jsonFormat2(SimpleOutgoingMessage)
 
   override val route: Route =
     path("ws-ingest") {
@@ -73,5 +75,11 @@ class IngestionWebSocketEndpoint(implicit system: ActorSystem, implicit val e: E
         case Failure(cause) => log.error(s"WS stream failed with $cause")
         case _ => //ignore
       }(e))
+
+}
+
+object IngestionWebSocketEndpoint extends ConfigSupport {
+
+  private[http] val maxNumberOfWSFrames: Int = rootConfig.get[Int]("hydra.ingest.websocket.max-frames").value
 
 }

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
@@ -20,9 +20,8 @@ import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.ws.{Message, TextMessage}
 import akka.http.scaladsl.server.Route
-import akka.stream.javadsl.RestartSource
-import akka.stream.{Materializer, StreamLimitReachedException}
 import akka.stream.scaladsl.{Flow, RestartFlow, Source}
+import akka.stream.{Materializer, StreamLimitReachedException}
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import configs.syntax._
 import hydra.common.config.ConfigSupport
@@ -32,8 +31,8 @@ import hydra.core.marshallers.GenericServiceResponse
 import hydra.ingest.services.{IngestSocketFactory, IngestionOutgoingMessage, SimpleOutgoingMessage}
 import spray.json._
 
-import scala.concurrent.{ExecutionContext, TimeoutException}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, TimeoutException}
 import scala.util.Failure
 
 /**

--- a/ingest/src/main/scala/hydra.ingest/services/DefaultIngestionHandler.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/DefaultIngestionHandler.scala
@@ -62,7 +62,7 @@ object DefaultIngestionHandler extends ConfigSupport {
 
   def props(request: HydraRequest, registry: ActorRef, requestor: ActorRef,
             timeout: FiniteDuration): Props = {
-    Props(classOf[DefaultIngestionHandler], request, registry, requestor, timeout)
+    Props(new DefaultIngestionHandler(request, registry, requestor, timeout))
   }
 }
 

--- a/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
@@ -1,12 +1,13 @@
 package hydra.ingest.services
 
+import akka.NotUsed
 import akka.actor.{ActorRef, ActorRefFactory, Props}
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import hydra.core.ingest.IngestionReport
 
 trait IngestSocketFactory {
-  def ingestFlow(): Flow[String, OutgoingMessage, Any]
+  def ingestFlow(): Flow[String, OutgoingMessage, NotUsed]
 }
 
 
@@ -28,7 +29,7 @@ object IngestSocketFactory {
           .mapMaterializedValue(socketActor ! SocketStarted(_))
 
       Flow.fromSinkAndSource(in, out)
-      
+
     }
   }
 }

--- a/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
@@ -7,13 +7,11 @@ import hydra.core.ingest.IngestionReport
 
 trait IngestSocketFactory {
   def ingestFlow(): Flow[String, OutgoingMessage, Any]
-
 }
 
 
 object IngestSocketFactory {
   def createSocket(fact: ActorRefFactory): IngestSocketFactory = {
-
     () => {
 
       val socketActor = fact.actorOf(Props[IngestionSocketActor])
@@ -22,7 +20,7 @@ object IngestSocketFactory {
 
       val in =
         Flow[String]
-          .map(IncomingMessage(_))
+          .map(IncomingMessage)
           .to(actorSink)
 
       val out =

--- a/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestSocketFactory.scala
@@ -28,7 +28,7 @@ object IngestSocketFactory {
         Source.actorRef[OutgoingMessage](1, OverflowStrategy.fail)
           .mapMaterializedValue(socketActor ! SocketStarted(_))
 
-      Flow.fromSinkAndSource(in, out)
+      Flow.fromSinkAndSourceCoupled(in, out)
 
     }
   }

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
@@ -17,8 +17,8 @@ import hydra.core.transport.{AckStrategy, ValidationStrategy}
 import hydra.ingest.bootstrap.HydraIngestorRegistryClient
 import hydra.ingest.services.IngestionSocketActor._
 
-import scala.concurrent.{ExecutionContext, TimeoutException}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, TimeoutException}
 import scala.util.{Success, Try}
 
 class IngestionSocketActor extends Actor with LoggingAdapter with ConfigSupport {
@@ -38,12 +38,8 @@ class IngestionSocketActor extends Actor with LoggingAdapter with ConfigSupport 
       context.become(ingestOrReceiveCommand(Some(actor), SocketSession()))
   }
 
-  private def ingestOrReceiveCommand(flowActor: Option[ActorRef], session: SocketSession): Receive = {
-    ingesting(flowActor, session) orElse commandReceive(flowActor, session) orElse {
-      case Failure(s: StreamLimitReachedException) => flowActor.foreach(_ !  SimpleOutgoingMessage(400, s"Frame limit reached after frame number ${s.n}."))
-      case Failure(t: TimeoutException) => flowActor.foreach(_ !  SimpleOutgoingMessage(400, s"Frames were sent over too long of a time."))
-    }
-  }
+  private def ingestOrReceiveCommand(flowActor: Option[ActorRef], session: SocketSession): Receive =
+    ingesting(flowActor, session) orElse commandReceive(flowActor, session)
 
   private def commandReceive(flowActor: Option[ActorRef], session: SocketSession): Receive = {
 

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
@@ -5,9 +5,8 @@ package hydra.ingest.services
   */
 
 import akka.actor.Status.Failure
-import akka.actor.{Actor, ActorRef}
+import akka.actor.{Actor, ActorRef, ActorSystem}
 import akka.http.scaladsl.model.StatusCodes
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.Timeout
 import hydra.common.config.ConfigSupport
 import hydra.common.logging.LoggingAdapter
@@ -17,77 +16,70 @@ import hydra.core.transport.{AckStrategy, ValidationStrategy}
 import hydra.ingest.bootstrap.HydraIngestorRegistryClient
 import hydra.ingest.services.IngestionSocketActor._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
 
 class IngestionSocketActor extends Actor with LoggingAdapter with ConfigSupport {
 
-  implicit val system = context.system
-
-  private var flowActor: ActorRef = _
-
-  implicit val timeout = 3.seconds
-
-  implicit val akkaTimeout = Timeout(timeout)
-
-  private var session: SocketSession = _
+  private implicit val system: ActorSystem = context.system
+  private implicit val akkaTimeout: Timeout = Timeout(3.seconds)
+  private implicit val ec: ExecutionContext = context.dispatcher
 
   private lazy val registry = context.
     actorSelection(HydraIngestorRegistryClient.registryPath(applicationConfig)).resolveOne()
 
-  private implicit val ec = context.dispatcher
 
-  override def preStart(): Unit = {
-    session = new SocketSession()
-  }
+  override def receive: Receive = waitForSocket
 
-  override def receive = waitForSocket
-
-  def waitForSocket: Receive = commandReceive orElse {
+  private lazy val waitForSocket: Receive = commandReceive(None, SocketSession()) orElse {
     case SocketStarted(actor) =>
-      flowActor = actor
-      context.become(ingesting orElse commandReceive)
+      context.become(ingestOrReceiveCommand(Some(actor), SocketSession()))
   }
 
-  def commandReceive: Receive = {
+  private def ingestOrReceiveCommand(flowActor: Option[ActorRef], session: SocketSession): Receive = {
+    ingesting(flowActor, session) orElse commandReceive(flowActor, session)
+  }
+
+  private def commandReceive(flowActor: Option[ActorRef], session: SocketSession): Receive = {
 
     case IncomingMessage(SetPattern(null, _)) =>
-      flowActor ! SimpleOutgoingMessage(200, session.metadata.mkString(";"))
+      flowActor.foreach(_ ! SimpleOutgoingMessage(200, session.metadata.mkString(";")))
 
     case IncomingMessage(SetPattern(key, value)) =>
       val theKey = key.toUpperCase.trim
       val theValue = value.trim
       log.debug(s"Setting metadata $theKey to $theValue")
       if (theKey.equalsIgnoreCase(RequestParams.HYDRA_ACK_STRATEGY)) { //this is a special case
-        val response = setAckStrategy(theValue)
-        flowActor ! SimpleOutgoingMessage(response._1, response._2)
+        val response = setAckStrategy(theValue, flowActor, session)
+        flowActor.foreach(_ ! SimpleOutgoingMessage(response._1, response._2))
       } else {
-        this.session = session.withMetadata(theKey -> theValue)
-        flowActor ! SimpleOutgoingMessage(200, s"OK[$theKey=$theValue]")
+        context.become(ingestOrReceiveCommand(flowActor, session.withMetadata(theKey -> theValue)))
+        flowActor.foreach(_ ! SimpleOutgoingMessage(200, s"OK[$theKey=$theValue]"))
       }
 
     case IncomingMessage(HelpPattern()) =>
-      flowActor ! SimpleOutgoingMessage(200, "Set metadata: --set (name)=(value)")
+      flowActor.foreach(_ ! SimpleOutgoingMessage(200, "Set metadata: --set (name)=(value)"))
 
     case IncomingMessage(_) =>
-      flowActor ! SimpleOutgoingMessage(400, "BAD_REQUEST:Not a valid message. Use 'HELP' for help.")
+      flowActor.foreach(_ ! SimpleOutgoingMessage(400, "BAD_REQUEST:Not a valid message. Use 'HELP' for help."))
 
     case SocketEnded =>
-      context.stop(flowActor)
+      flowActor.foreach(context.stop)
       context.stop(self)
   }
 
-  private def setAckStrategy(strategy: String): (Int, String) = {
+  private def setAckStrategy(strategy: String, flowActor: Option[ActorRef], session: SocketSession): (Int, String) = {
     val key = RequestParams.HYDRA_ACK_STRATEGY
     AckStrategy(strategy).map { ack =>
-      this.session = session.withMetadata(key -> ack.toString)
+      context.become(ingestOrReceiveCommand(flowActor, session.withMetadata(key -> ack.toString)))
       200 -> s"OK[$key=$strategy]"
     }.recover {
       case e: Exception => 400 -> s"BAD REQUEST[$key=$strategy] is not a valid ack strategy."
     }.get
   }
 
-  def ingesting: Receive = {
+  def ingesting(flowActor: Option[ActorRef], session: SocketSession): Receive = {
     case IncomingMessage(IngestPattern(correlationId, payload)) =>
       registry.foreach { r =>
         val request = session.buildRequest(Option(correlationId), payload)
@@ -95,15 +87,13 @@ class IngestionSocketActor extends Actor with LoggingAdapter with ConfigSupport 
           case Success(req) => context.actorOf(DefaultIngestionHandler.props(req, r, self))
           case scala.util.Failure(ex) => sender ! Failure(ex)
         }
-
       }
-
     case report: IngestionReport =>
-      flowActor ! IngestionOutgoingMessage(report)
-
+      flowActor.foreach(_ ! IngestionOutgoingMessage(report))
     case e: HydraError =>
-      flowActor ! SimpleOutgoingMessage(StatusCodes.InternalServerError.intValue, e.cause.getMessage)
+      flowActor.foreach(_ ! SimpleOutgoingMessage(StatusCodes.InternalServerError.intValue, e.cause.getMessage))
   }
+
 }
 
 object IngestionSocketActor {
@@ -114,7 +104,7 @@ object IngestionSocketActor {
 
 case class SocketSession(metadata: Map[String, String] = Map.empty) {
 
-  def withMetadata(meta: (String, String)*) =
+  def withMetadata(meta: (String, String)*): SocketSession =
     copy(metadata = this.metadata ++ meta.map(m => m._1 -> m._2))
 
   def buildRequest(correlationId: Option[String], payload: String): Try[HydraRequest] = {

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
@@ -29,10 +29,9 @@ class IngestionSocketActor extends Actor with LoggingAdapter with ConfigSupport 
   private lazy val registry = context.
     actorSelection(HydraIngestorRegistryClient.registryPath(applicationConfig)).resolveOne()
 
-
   override def receive: Receive = waitForSocket
 
-  private lazy val waitForSocket: Receive = {
+  private val waitForSocket: Receive = {
     case SocketStarted(actor) =>
       context.become(ingestOrReceiveCommand(actor, SocketSession()))
   }

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSocketActor.scala
@@ -7,6 +7,7 @@ package hydra.ingest.services
 import akka.actor.Status.Failure
 import akka.actor.{Actor, ActorRef}
 import akka.http.scaladsl.model.StatusCodes
+import akka.stream.{ActorMaterializer, Materializer}
 import akka.util.Timeout
 import hydra.common.config.ConfigSupport
 import hydra.common.logging.LoggingAdapter

--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -12,6 +12,7 @@ hydra_test {
     websocket {
       enabled = true
       max-frames = 50
+      stream-timeout = 10 seconds
     }
   }
 

--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -12,7 +12,7 @@ hydra_test {
     websocket {
       enabled = true
       max-frames = 50
-      stream-timeout = 10 seconds
+      stream-timeout = 5 seconds
     }
   }
 
@@ -31,7 +31,7 @@ akka {
   test {
     # factor by which to scale timeouts during tests, e.g. to account for shared
     # build system load
-    timefactor = 3.0
+    timefactor = 5.0
   }
   remote {
     artery {

--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -9,7 +9,10 @@ hydra_test {
 
   ingest {
     ingestor-registry.path = "/user/ingestor_registry"
-    websocket.enabled = true
+    websocket {
+      enabled = true
+      max-frames = 50
+    }
   }
 
   transports {

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -1,11 +1,12 @@
 package hydra.ingest.http
 
 import akka.actor.Actor
-import akka.http.scaladsl.model.ws.TextMessage
+import akka.http.scaladsl.model.ws.{BinaryMessage, TextMessage}
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, WSProbe}
 import akka.pattern.pipe
 import akka.stream.scaladsl.Source
 import akka.testkit.{TestActorRef, TestKit}
+import akka.util.ByteString
 import hydra.core.protocol._
 import hydra.ingest.IngestorInfo
 import hydra.ingest.services.IngestorRegistry.{FindAll, FindByName, LookupResult}
@@ -149,6 +150,9 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
 
         wsClient.sendMessage(TextMessage.Streamed(Source(1 to 10).map(_.toString).throttle(1, IngestionWebSocketEndpoint.streamedWSMessageTimeout)))
         wsClient.expectMessage("""{"message":"Timeout on frame buffer reached.","status":400}""")
+
+        wsClient.sendMessage(BinaryMessage.apply(ByteString("")))
+        wsClient.expectMessage("""{"message":"Binary messages are not supported.","status":400}""")
 
         wsClient.sendMessage(TextMessage.Streamed(Source("-c SET hydra-delivery-" :: "strategy = at-most-once" :: Nil)))
         wsClient.expectMessage("""{"message":"OK[HYDRA-DELIVERY-STRATEGY=at-most-once]","status":200}""")

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -144,7 +144,13 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
         // check response for WS Upgrade headers
         isWebSocketUpgrade shouldEqual true
 
-        wsClient.sendMessage(TextMessage.Streamed(Source(List.range(1, IngestionWebSocketEndpoint.maxNumberOfWSFrames + 1).map(_.toString))))
+        wsClient.sendMessage(
+          TextMessage
+            .Streamed(Source("""--asdf-c SET hydra-kafka-topic = test.Topic}}}}}}}}}}}}}}}"""
+              .toCharArray
+              .map(_.toString)
+              .toList))
+        )
         wsClient.expectMessage("""{"message":"BAD_REQUEST:Not a valid message. Use 'HELP' for help.","status":400}""")
 
         wsClient.sendCompletion()

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -144,14 +144,11 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
         // check response for WS Upgrade headers
         isWebSocketUpgrade shouldEqual true
 
-        wsClient.sendMessage(
-          TextMessage
-            .Streamed(Source("""--asdf-c SET hydra-kafka-topic = test.Topic}}}}}}}}}}}}}}}"""
-              .toCharArray
-              .map(_.toString)
-              .toList))
-        )
-        wsClient.expectMessage("""{"message":"BAD_REQUEST:Not a valid message. Use 'HELP' for help.","status":400}""")
+        wsClient.sendMessage(TextMessage.Streamed(Source(List.fill(55)("A"))))
+        wsClient.expectMessage("""{"message":"Frame limit reached after frame number 50.","status":400}""")
+
+        wsClient.sendMessage(TextMessage.Streamed(Source("-c SET hydra-delivery-" :: "strategy = at-most-once" :: Nil)))
+        wsClient.expectMessage("""{"message":"OK[HYDRA-DELIVERY-STRATEGY=at-most-once]","status":200}""")
 
         wsClient.sendCompletion()
         wsClient.expectCompletion()

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -144,10 +144,10 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
         // check response for WS Upgrade headers
         isWebSocketUpgrade shouldEqual true
 
-        wsClient.sendMessage(TextMessage.Streamed(Source(1 to 55).map(_.toString)))
+        wsClient.sendMessage(TextMessage.Streamed(Source(1 to IngestionWebSocketEndpoint.maxNumberOfWSFrames + 1).map(_.toString)))
         wsClient.expectMessage("""{"message":"Frame limit reached after frame number 50.","status":400}""")
 
-        wsClient.sendMessage(TextMessage.Streamed(Source(1 to 55).map(_.toString).throttle(1, 5.seconds)))
+        wsClient.sendMessage(TextMessage.Streamed(Source(1 to 2).map(_.toString).throttle(1, IngestionWebSocketEndpoint.streamedWSMessageTimeout)))
         wsClient.expectMessage("""{"message":"Timeout on frame buffer reached.","status":400}""")
 
         wsClient.sendMessage(TextMessage.Streamed(Source("-c SET hydra-delivery-" :: "strategy = at-most-once" :: Nil)))

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionWebSocketEndpointSpec.scala
@@ -147,7 +147,7 @@ class IngestionWebSocketEndpointSpec extends Matchers with WordSpecLike with Sca
         wsClient.sendMessage(TextMessage.Streamed(Source(1 to IngestionWebSocketEndpoint.maxNumberOfWSFrames + 1).map(_.toString)))
         wsClient.expectMessage("""{"message":"Frame limit reached after frame number 50.","status":400}""")
 
-        wsClient.sendMessage(TextMessage.Streamed(Source(1 to 2).map(_.toString).throttle(1, IngestionWebSocketEndpoint.streamedWSMessageTimeout)))
+        wsClient.sendMessage(TextMessage.Streamed(Source(1 to 10).map(_.toString).throttle(1, IngestionWebSocketEndpoint.streamedWSMessageTimeout)))
         wsClient.expectMessage("""{"message":"Timeout on frame buffer reached.","status":400}""")
 
         wsClient.sendMessage(TextMessage.Streamed(Source("-c SET hydra-delivery-" :: "strategy = at-most-once" :: Nil)))


### PR DESCRIPTION
This PR includes a few improvements:

1. Handling `TextMessage.Streamed` in addition to `TextMessage.Strict`. This means that WS messages with more than one frame will now be handled. I also added the ability to cap the number of total frames in a single message and the amount of time a single message can take to arrive. These values are configurable and I just threw in what I thought were reasonable defaults (they can be overridden with env vars). Although this isn't an urgent change, it is technically needed for us to conform to the RFC 6455 spec for Web Sockets so it will be good to add.

2. The IngestionSocketActor was previously keeping a class level property for mutable state. I updated this to use the `context.become` functionality to mutate state. This is more preference than anything else, but I think it is a good change. See [Scala best practices](https://github.com/alexandru/scala-best-practices/blob/master/sections/5-actors.md#52-should-mutate-state-in-actors-only-with-contextbecome) for more information.