### PR TITLE
moving materializer into ws class

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
@@ -20,8 +20,8 @@ import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.ws.{BinaryMessage, Message, TextMessage}
 import akka.http.scaladsl.server.Route
+import akka.stream.StreamLimitReachedException
 import akka.stream.scaladsl.{Flow, RestartFlow, Source}
-import akka.stream.{ActorMaterializer, Materializer, StreamLimitReachedException}
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import configs.syntax._
 import hydra.common.config.ConfigSupport

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
@@ -41,8 +41,6 @@ import scala.util.Failure
 class IngestionWebSocketEndpoint(implicit system: ActorSystem, e: ExecutionContext)
   extends RoutedEndpoints with LoggingAdapter with HydraIngestJsonSupport with HydraDirectives {
 
-  implicit val materializer: Materializer = ActorMaterializer()
-
   //visible for testing
   private[http] val enabled = applicationConfig.get[Boolean]("ingest.websocket.enabled")
     .valueOrElse(false)

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionWebSocketEndpoint.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.ws.{BinaryMessage, Message, TextMessage}
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.{Flow, RestartFlow, Source}
-import akka.stream.{Materializer, StreamLimitReachedException}
+import akka.stream.{ActorMaterializer, Materializer, StreamLimitReachedException}
 import com.github.vonnagy.service.container.http.routing.RoutedEndpoints
 import configs.syntax._
 import hydra.common.config.ConfigSupport
@@ -38,8 +38,10 @@ import scala.util.Failure
 /**
   * Created by alexsilva on 12/22/15.
   */
-class IngestionWebSocketEndpoint(implicit system: ActorSystem, e: ExecutionContext, materializer: Materializer)
+class IngestionWebSocketEndpoint(implicit system: ActorSystem, e: ExecutionContext)
   extends RoutedEndpoints with LoggingAdapter with HydraIngestJsonSupport with HydraDirectives {
+
+  implicit val materializer: Materializer = ActorMaterializer()
 
   //visible for testing
   private[http] val enabled = applicationConfig.get[Boolean]("ingest.websocket.enabled")


### PR DESCRIPTION
So apparently I introduced a runtime error on my first commit 🤦‍♂, so here is a fix for that.

RoutedEndpoints provides an actor system and an execution context, but not a materializer so I had to create one myself within the class.