### PR TITLE
Change JsonConverter to debug

### DIFF
--- a/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
+++ b/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
@@ -218,7 +218,7 @@ public class JsonConverter<T extends GenericRecord> {
 
         if (usedFields.size() < raw.size()) {
             Set unknownFields = Sets.difference(raw.keySet(), usedFields);
-            LOG.warn("There are unused JSON fields: " + Sets.difference(raw.keySet(), usedFields));
+            LOG.debug("There are unused JSON fields: " + Sets.difference(raw.keySet(), usedFields));
             conversionStats.reportUnknownFields(unknownFields);
         }
 


### PR DESCRIPTION
This will significantly reduce the amount of noise in our logs. If we need to see the unused JSON fields, we can turn on debug logging. 