### PR TITLE
Timeout Logs One Line

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/services/IngestionSupervisor.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionSupervisor.scala
@@ -100,12 +100,8 @@ class IngestionSupervisor(
     case ReceiveTimeout =>
       //get status for ingestors
       val errorMsg =
-        s"""${request.correlationId}:
-           |Ack:${request.ackStrategy};
-           |Validation: ${request.validationStrategy};
-           |Metadata:${request.metadata};
-           |Payload: ${request.payload}
-           |Ingestors:  ${ingestors.toString}""".stripMargin
+        s"${request.correlationId}: Ack:${request.ackStrategy}; Validation: ${request.validationStrategy};" +
+          s" Metadata:${request.metadata}; Payload: ${request.payload} Ingestors: ${ingestors.toString}; Timeout: $timeout"
       log.error(s"Ingestion timed out for request $errorMsg")
       context.system.eventStream.publish(
         IngestionTimedOut(request, start, timeout, ingestors.keys.mkString(","))


### PR DESCRIPTION
Loki requires logs to not contain newlines. Timeout logs are getting cut off in that system. This PR moves the timeout logs to a single line.﻿
