### PR TITLE
Remove Unused Logs

### DIFF
--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -5,6 +5,7 @@ hydra_test {
   http.interface = 0.0.0.0
   kafka {
     producer.bootstrap.servers = "localhost:6001"
+    admin.bootstrap.servers = "localhost:6001"
     consumer.zookeeper.connect = "localhost:6000"
   }
   schema.registry.url = "mock"

--- a/ingestors/kafka/src/main/resources/reference.conf
+++ b/ingestors/kafka/src/main/resources/reference.conf
@@ -119,6 +119,11 @@ hydra {
       auto.offset.reset = latest
     }
 
+    admin {
+      bootstrap.servers = "localhost:29092"
+      bootstrap.servers = ${?HYDRA_KAFKA_PRODUCER_BOOTSTRAP_SERVERS}
+    }
+
     producer {
       bootstrap.servers = "localhost:29092"
       bootstrap.servers = ${?HYDRA_KAFKA_PRODUCER_BOOTSTRAP_SERVERS}

--- a/ingestors/kafka/src/main/scala/hydra/kafka/ingestors/KafkaIngestor.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/ingestors/KafkaIngestor.scala
@@ -49,7 +49,7 @@ class KafkaIngestor extends Ingestor with KafkaProducerSupport {
 
   private val topicActor = context.actorOf(
     KafkaTopicsActor
-      .props(KafkaConfigSupport.kafkaConfig.getConfig("kafka.producer"))
+      .props(KafkaConfigSupport.kafkaConfig.getConfig("kafka.admin"))
   )
 
   ingest {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/util/KafkaUtils.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/util/KafkaUtils.scala
@@ -171,5 +171,5 @@ object KafkaUtils extends ConfigSupport {
     KafkaUtils(ConfigSupport.toMap(config))
 
   def apply(): KafkaUtils =
-    apply(KafkaConfigSupport.kafkaConfig.getConfig("kafka.producer"))
+    apply(KafkaConfigSupport.kafkaConfig.getConfig("kafka.admin"))
 }

--- a/ingestors/kafka/src/test/resources/reference.conf
+++ b/ingestors/kafka/src/test/resources/reference.conf
@@ -95,6 +95,10 @@ hydra_kafka {
       key.serializer = org.apache.kafka.common.serialization.StringSerializer
     }
 
+    admin {
+      bootstrap.servers = "localhost:8092"
+    }
+
     consumer {
       bootstrap.servers = "localhost:8092"
       zookeeper.connect = "localhost:3181"


### PR DESCRIPTION
This will get rid of the logs: The configuration ... was supplied but isn't a known config. For:

key.serializer
max.in.flight.requests.per.connection