### PR TITLE
increase the initial sizes of actor router pools

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -49,7 +49,7 @@ akka {
       #Do not remove this; if ingestors are not configured with a router under akka.deployment.actor,
       #a round-robin router is used with this configuration.
       default-ingestor-router {
-        nr-of-instances = 2
+        nr-of-instances = 15
         optimal-size-exploring-resizer {
           enabled = false
         }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/producer/KafkaProducerSupport.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/producer/KafkaProducerSupport.scala
@@ -35,7 +35,7 @@ trait KafkaProducerSupport extends TransportOps {
   override def transportName: String = "kafka"
 
   private val pool = RoundRobinPool(
-    nrOfInstances = 5,
+    nrOfInstances = 20,
     resizer = Some(DefaultOptimalSizeExploringResizer())
   )
 


### PR DESCRIPTION
Currently, we have a really low default for the nrOfInstances in our router pools. This could make things less performant on application start. The maximums for our router pools are 30 and 20 and we were defaulting to 5 and 2 for the initial number. This seems far to small. If nothing else trying a larger number seems like it is worth a shot.
