### PR TITLE
New Ingest Flow

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
@@ -83,11 +83,11 @@ object AppConfig {
                                  useOldIngestIfUAContains: Set[String]
                                )
 
-  private implicit def decodeSetStrings
+  private[app] implicit def decodeSetStrings
   : ConfigDecoder[String, Set[String]] =
     ConfigDecoder
       .identity[String]
-      .mapOption("Set[String]")(s => Some(s.split(",").toSet))
+      .mapOption("Set[String]")(s => Some(if (s.isEmpty) Set.empty else s.split(",").toSet))
 
   private val ingestConfig: ConfigValue[IngestConfig] =
     (

--- a/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
@@ -79,13 +79,21 @@ object AppConfig {
     ).parMapN(V2MetadataTopicConfig)
 
   final case class IngestConfig(
-                                 alternateIngestEnabled: Boolean
+                                 alternateIngestEnabled: Boolean,
+                                 useOldIngestIfUAContains: Set[String]
                                )
+
+  private implicit def decodeSetStrings
+  : ConfigDecoder[String, Set[String]] =
+    ConfigDecoder
+      .identity[String]
+      .mapOption("Set[String]")(s => Some(s.split(",").toSet))
 
   private val ingestConfig: ConfigValue[IngestConfig] =
     (
-      env("HYDRA_INGEST_ALTERNATE_ENABLED").as[Boolean].default(false)
-    ).map(IngestConfig)
+      env("HYDRA_INGEST_ALTERNATE_ENABLED").as[Boolean].default(false),
+      env("HYDRA_INGEST_ALTERNATE_IGNORE_UA_STRINGS").as[Set[String]].default(Set.empty)
+    ).parMapN(IngestConfig)
 
   final case class AppConfig(
       createTopicConfig: CreateTopicConfig,

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
@@ -24,11 +24,11 @@ import hydra.common.util.Futurable
 import hydra.core.http.RouteSupport
 import hydra.core.ingest.{CorrelationIdBuilder, HydraRequest, IngestionReport, RequestParams}
 import hydra.core.marshallers.GenericError
-import hydra.core.protocol.{IngestorCompleted, InitiateHttpRequest, RequestPublished}
+import hydra.core.protocol.{IngestorCompleted, InitiateHttpRequest}
 import hydra.ingest.bootstrap.HydraIngestorRegistryClient
 import hydra.ingest.services.IngestionHandlerGateway
 
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration._
 
 /**
   * Created by alexsilva on 12/22/15.
@@ -36,7 +36,7 @@ import scala.concurrent.duration.{FiniteDuration, _}
 class IngestionEndpoint[F[_]: Futurable](
                                           alternateIngestFlowEnabled: Boolean,
                                           ingestionFlow: IngestionFlow[F],
-                                          useOldIngestUAContains: Set[String],
+                                          useOldIngestIfUAContains: Set[String],
                                           requestHandlerPathName: Option[String] = None
                                         )(implicit system: ActorSystem) extends RouteSupport with HydraIngestJsonSupport {
 
@@ -76,7 +76,7 @@ class IngestionEndpoint[F[_]: Futurable](
 
   private def useAlternateIngestFlow(request: HydraRequest): Boolean = {
     request.metadata.find(e => e._1.equalsIgnoreCase("User-Agent")) match {
-      case Some(ua) if useOldIngestUAContains.exists(ua._2.startsWith) => false
+      case Some(ua) if useOldIngestIfUAContains.exists(ua._2.startsWith) => false
       case _ => true
     }
   }

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
@@ -26,7 +26,7 @@ import hydra.core.ingest.{CorrelationIdBuilder, HydraRequest, IngestionReport, R
 import hydra.core.marshallers.GenericError
 import hydra.core.protocol.{IngestorCompleted, IngestorJoined, InitiateHttpRequest}
 import hydra.ingest.bootstrap.HydraIngestorRegistryClient
-import hydra.ingest.services.IngestionHandlerGateway
+import hydra.ingest.services.{IngestionFlow, IngestionHandlerGateway}
 import hydra.kafka.algebras.KafkaClientAlgebra.PublishError
 
 import scala.concurrent.duration._

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionFlow.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionFlow.scala
@@ -43,7 +43,7 @@ final class IngestionFlow[F[_]: MonadError[*[_], Throwable]: Mode](schemaRegistr
           .mkString("|")
         kafkaClient.publishStringKeyMessage((key, ar.payload), topic)
       }.void
-      case None => throw new Exception
+      case None => throw new Exception // TODO: Handle this error - Return a 4xx error
     }
   }
 }

--- a/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
@@ -3,7 +3,7 @@ package hydra.ingest.modules
 import cats.effect._
 import cats.implicits._
 import hydra.ingest.app.AppConfig.AppConfig
-import hydra.ingest.http.IngestionFlow
+import hydra.ingest.services.IngestionFlow
 import hydra.kafka.programs.CreateTopicProgram
 import io.chrisdavenport.log4cats.Logger
 import retry.RetryPolicies._

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -43,7 +43,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
       new TopicMetadataEndpoint(consumerProxy)(system.dispatcher).route ~
       new IngestorRegistryEndpoint().route ~
       new IngestionWebSocketEndpoint().route ~
-      new IngestionEndpoint(cfg.ingestConfig.alternateIngestEnabled, programs.ingestionFlow, Set.empty).route ~
+      new IngestionEndpoint(cfg.ingestConfig.alternateIngestEnabled, programs.ingestionFlow, cfg.ingestConfig.useOldIngestIfUAContains).route ~
       new TopicsEndpoint(consumerProxy)(system.dispatcher).route ~
       HealthEndpoint.route ~
       bootstrapEndpointV2

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -43,7 +43,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
       new TopicMetadataEndpoint(consumerProxy)(system.dispatcher).route ~
       new IngestorRegistryEndpoint().route ~
       new IngestionWebSocketEndpoint().route ~
-      new IngestionEndpoint(cfg.ingestConfig.alternateIngestEnabled, programs.ingestionFlow).route ~
+      new IngestionEndpoint(cfg.ingestConfig.alternateIngestEnabled, programs.ingestionFlow, Set.empty).route ~
       new TopicsEndpoint(consumerProxy)(system.dispatcher).route ~
       HealthEndpoint.route ~
       bootstrapEndpointV2

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionFlow.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionFlow.scala
@@ -1,4 +1,4 @@
-package hydra.ingest.http
+package hydra.ingest.services
 
 import cats.MonadError
 import cats.implicits._

--- a/ingest/src/test/scala/hydra/ingest/app/AppConfigSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/app/AppConfigSpec.scala
@@ -1,0 +1,17 @@
+package hydra.ingest.app
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import cats.implicits._
+
+final class AppConfigSpec extends AnyFlatSpec with Matchers {
+
+  it should "parse a list of comma separated strings into a set" in {
+    AppConfig.decodeSetStrings.decode(None, "test,test2,test3") shouldBe Set("test", "test2", "test3").asRight
+  }
+
+  it should "parse an empty string into an empty set" in {
+    AppConfig.decodeSetStrings.decode(None, "") shouldBe Set.empty.asRight
+  }
+
+}

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
@@ -13,6 +13,7 @@ import hydra.core.ingest.RequestParams
 import hydra.core.ingest.RequestParams.HYDRA_KAFKA_TOPIC_PARAM
 import hydra.core.marshallers.GenericError
 import hydra.ingest.IngestorInfo
+import hydra.ingest.services.IngestionFlow
 import hydra.ingest.services.IngestorRegistry.{FindAll, FindByName, LookupResult}
 import hydra.ingest.test.TestIngestor
 import hydra.kafka.algebras.KafkaClientAlgebra

--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -105,9 +105,9 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
 
     override def consumeMessages(topicName: TopicName, consumerGroup: String): fs2.Stream[IO, (GenericRecord, GenericRecord)] = fs2.Stream.empty
 
-    override def publishStringKeyMessage(record: (String, GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
+    override def publishStringKeyMessage(record: (Option[String], GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
 
-    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (String, GenericRecord)] = ???
+    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (Option[String], GenericRecord)] = ???
   }
 
 }

--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -5,14 +5,12 @@ import cats.effect.{IO, Sync, Timer}
 import cats.implicits._
 import hydra.avro.registry.SchemaRegistry
 import hydra.ingest.app.AppConfig.V2MetadataTopicConfig
-import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra}
 import hydra.kafka.algebras.KafkaAdminAlgebra.Topic
-import hydra.kafka.algebras.KafkaClientAlgebra.{PublishError, TopicName}
+import hydra.kafka.algebras.KafkaClientAlgebra.{ConsumerGroup, PublishError, TopicName}
+import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra}
 import hydra.kafka.model.ContactMethod
 import hydra.kafka.model.TopicMetadataV2Request.Subject
-import hydra.kafka.producer.KafkaRecord
 import hydra.kafka.programs.CreateTopicProgram
-import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.apache.avro.generic.GenericRecord
@@ -108,6 +106,8 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
     override def consumeMessages(topicName: TopicName, consumerGroup: String): fs2.Stream[IO, (GenericRecord, GenericRecord)] = fs2.Stream.empty
 
     override def publishStringKeyMessage(record: (String, GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
+
+    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (String, GenericRecord)] = ???
   }
 
 }

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
@@ -1,0 +1,65 @@
+package hydra.ingest.services
+
+import cats.effect.{Concurrent, ContextShift, IO}
+import hydra.avro.registry.SchemaRegistry
+import hydra.core.ingest.HydraRequest
+import hydra.core.ingest.RequestParams.HYDRA_KAFKA_TOPIC_PARAM
+import hydra.kafka.algebras.KafkaClientAlgebra
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext
+
+class IngestionFlowSpec extends AnyFlatSpec with Matchers {
+
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val concurrentEffect: Concurrent[IO] = IO.ioConcurrentEffect
+  private implicit val mode: scalacache.Mode[IO] = scalacache.CatsEffect.modes.async
+
+  private val testSubject: String = "test_subject"
+
+  private val testSubjectNoKey: String = "test_subject_no_key"
+
+  private val testKey: String = "test"
+
+  private val testPayload: String =
+    s"""{"id": "$testKey", "testField": true}"""
+
+  private val testSchema: Schema = SchemaBuilder.record("TestRecord")
+    .prop("hydra.key", "id")
+    .fields().requiredString("id").requiredBoolean("testField").endRecord()
+
+  private val testSchemaNoKey: Schema = SchemaBuilder.record("TestRecordNoKey")
+    .fields().requiredString("id").requiredBoolean("testField").endRecord()
+
+  private def ingest(request: HydraRequest): IO[KafkaClientAlgebra[IO]] = for {
+    schemaRegistry <- SchemaRegistry.test[IO]
+    _ <- schemaRegistry.registerSchema(testSubject + "-value", testSchema)
+    _ <- schemaRegistry.registerSchema(testSubjectNoKey + "-value", testSchemaNoKey)
+    kafkaClient <- KafkaClientAlgebra.test[IO]
+    ingestFlow <- IO(new IngestionFlow[IO](schemaRegistry, kafkaClient))
+    _ <- ingestFlow.ingest(request)
+  } yield kafkaClient
+
+  it should "ingest a message" in {
+    val testRequest = HydraRequest("correlationId", testPayload, metadata = Map(HYDRA_KAFKA_TOPIC_PARAM -> testSubject))
+    ingest(testRequest).flatMap { kafkaClient =>
+      kafkaClient.consumeStringKeyMessages(testSubject, "test-consumer").take(1).compile.toList.map { publishedMessages =>
+        val firstMessage = publishedMessages.head
+        (firstMessage._1, firstMessage._2.toString) shouldBe (testKey, testPayload)
+      }
+    }.unsafeRunSync()
+  }
+
+  it should "ingest a message with a null key" in {
+    val testRequest = HydraRequest("correlationId", testPayload, metadata = Map(HYDRA_KAFKA_TOPIC_PARAM -> testSubjectNoKey))
+    ingest(testRequest).flatMap { kafkaClient =>
+      kafkaClient.consumeStringKeyMessages(testSubjectNoKey, "test-consumer").take(1).compile.toList.map { publishedMessages =>
+        val firstMessage = publishedMessages.head
+        (firstMessage._1, firstMessage._2.toString) shouldBe (null, testPayload)
+      }
+    }.unsafeRunSync()
+  }
+
+}

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
@@ -48,7 +48,7 @@ class IngestionFlowSpec extends AnyFlatSpec with Matchers {
     ingest(testRequest).flatMap { kafkaClient =>
       kafkaClient.consumeStringKeyMessages(testSubject, "test-consumer").take(1).compile.toList.map { publishedMessages =>
         val firstMessage = publishedMessages.head
-        (firstMessage._1, firstMessage._2.toString) shouldBe (Some(testKey), testPayload)
+        (firstMessage._1, firstMessage._2.get.toString) shouldBe (Some(testKey), testPayload)
       }
     }.unsafeRunSync()
   }
@@ -58,7 +58,7 @@ class IngestionFlowSpec extends AnyFlatSpec with Matchers {
     ingest(testRequest).flatMap { kafkaClient =>
       kafkaClient.consumeStringKeyMessages(testSubjectNoKey, "test-consumer").take(1).compile.toList.map { publishedMessages =>
         val firstMessage = publishedMessages.head
-        (firstMessage._1, firstMessage._2.toString) shouldBe (None, testPayload)
+        (firstMessage._1, firstMessage._2.get.toString) shouldBe (None, testPayload)
       }
     }.unsafeRunSync()
   }

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
@@ -47,7 +47,7 @@ class IngestionFlowSpec extends AnyFlatSpec with Matchers {
     ingest(testRequest).flatMap { kafkaClient =>
       kafkaClient.consumeStringKeyMessages(testSubject, "test-consumer").take(1).compile.toList.map { publishedMessages =>
         val firstMessage = publishedMessages.head
-        (firstMessage._1, firstMessage._2.toString) shouldBe (testKey, testPayload)
+        (firstMessage._1, firstMessage._2.toString) shouldBe (Some(testKey), testPayload)
       }
     }.unsafeRunSync()
   }
@@ -57,7 +57,7 @@ class IngestionFlowSpec extends AnyFlatSpec with Matchers {
     ingest(testRequest).flatMap { kafkaClient =>
       kafkaClient.consumeStringKeyMessages(testSubjectNoKey, "test-consumer").take(1).compile.toList.map { publishedMessages =>
         val firstMessage = publishedMessages.head
-        (firstMessage._1, firstMessage._2.toString) shouldBe (null, testPayload)
+        (firstMessage._1, firstMessage._2.toString) shouldBe (None, testPayload)
       }
     }.unsafeRunSync()
   }

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.{Concurrent, ContextShift, IO}
 import hydra.avro.registry.SchemaRegistry
 import hydra.core.ingest.HydraRequest
 import hydra.core.ingest.RequestParams.HYDRA_KAFKA_TOPIC_PARAM
+import hydra.ingest.services.IngestionFlow.MissingTopicNameException
 import hydra.kafka.algebras.KafkaClientAlgebra
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -60,6 +61,11 @@ class IngestionFlowSpec extends AnyFlatSpec with Matchers {
         (firstMessage._1, firstMessage._2.toString) shouldBe (None, testPayload)
       }
     }.unsafeRunSync()
+  }
+
+  it should "return an error when no topic name is provided" in {
+    val testRequest = HydraRequest("correlationId", testPayload)
+    ingest(testRequest).attempt.unsafeRunSync() shouldBe Left(MissingTopicNameException(testRequest))
   }
 
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/MetadataAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/MetadataAlgebra.scala
@@ -21,7 +21,7 @@ trait MetadataAlgebra[F[_]] {
 
 object MetadataAlgebra {
 
-  final case class TopicMetadataV2Container(key: TopicMetadataV2Key, value: TopicMetadataV2Value)
+  final case class TopicMetadataV2Container(key: TopicMetadataV2Key, value: Option[TopicMetadataV2Value])
 
   def make[F[_]: Sync: Concurrent](
                         metadataTopicName: TopicName,
@@ -29,7 +29,7 @@ object MetadataAlgebra {
                         kafkaClientAlgebra: KafkaClientAlgebra[F],
                         consumeMetadataEnabled: Boolean
                       ): F[MetadataAlgebra[F]] = {
-    val metadataStream: fs2.Stream[F, (GenericRecord, GenericRecord)] = if (consumeMetadataEnabled) {
+    val metadataStream: fs2.Stream[F, (GenericRecord, Option[GenericRecord])] = if (consumeMetadataEnabled) {
       kafkaClientAlgebra.consumeMessages(metadataTopicName, consumerGroup)
     } else {
       fs2.Stream.empty

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
@@ -73,7 +73,7 @@ object TopicMetadataV2 {
       }
       .rethrow
       .flatMap {
-        case (k: GenericRecord, v: Option[GenericRecord]) => Monad[F].pure((k, v))
+        case (k: GenericRecord, v: GenericRecord) => Monad[F].pure((k, Option(v)))
         case (k, v) =>
           MonadError[F, Throwable].raiseError(
             AvroEncodingFailure(

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
@@ -51,24 +51,29 @@ object TopicMetadataV2 {
 
   def encode[F[_]: MonadError[*[_], Throwable]](
       key: TopicMetadataV2Key,
-      value: TopicMetadataV2Value
-  ): F[(GenericRecord, GenericRecord)] = {
+      value: Option[TopicMetadataV2Value]
+  ): F[(GenericRecord, Option[GenericRecord])] = {
     Monad[F]
-      .pure(
+      .pure {
+        val valueResult: Option[Either[AvroError, Any]] = value.map(TopicMetadataV2Value.codec.encode)
         (
           Validated
             .fromEither(TopicMetadataV2Key.codec.encode(key))
             .toValidatedNel,
-          Validated
-            .fromEither(TopicMetadataV2Value.codec.encode(value))
-            .toValidatedNel
-        ).tupled.toEither.leftMap{ a =>
+          valueResult match {
+            case Some(e: Either[AvroError, Any]) =>
+              Validated
+                .fromEither(e)
+                .toValidatedNel
+            case None => None.validNel
+          }
+          ).tupled.toEither.leftMap { a =>
           MetadataAvroSchemaFailure(a)
         }
-      )
+      }
       .rethrow
       .flatMap {
-        case (k: GenericRecord, v: GenericRecord) => Monad[F].pure((k, v))
+        case (k: GenericRecord, v: Option[GenericRecord]) => Monad[F].pure((k, v))
         case (k, v) =>
           MonadError[F, Throwable].raiseError(
             AvroEncodingFailure(
@@ -80,23 +85,28 @@ object TopicMetadataV2 {
 
   def decode[F[_]: MonadError[*[_], Throwable]](
                                                key: GenericRecord,
-                                               value: GenericRecord
-                                               ): F[(TopicMetadataV2Key, TopicMetadataV2Value)] = {
+                                               value: Option[GenericRecord]
+                                               ): F[(TopicMetadataV2Key, Option[TopicMetadataV2Value])] = {
     getSchemas[F].flatMap { schemas =>
       Monad[F]
-        .pure(
+        .pure {
+          val valueResult: Option[Either[AvroError, TopicMetadataV2Value]] = value.map(TopicMetadataV2Value.codec.decode(_, schemas.value))
           (
             Validated
               .fromEither(TopicMetadataV2Key.codec.decode(key, schemas.key))
               .toValidatedNel,
-            Validated
-              .fromEither(TopicMetadataV2Value.codec.decode(value, schemas.value))
-              .toValidatedNel
+            valueResult match {
+              case Some(Left(avroError)) =>
+               avroError.invalidNel
+              case Some(Right(topicMetadataV2Value)) =>
+                Some(topicMetadataV2Value).validNel
+              case None => None.validNel
+            }
             ).tupled.toEither
-            .leftMap{ a =>
-            MetadataAvroSchemaFailure(a)
-          }
-        )
+            .leftMap { a =>
+              MetadataAvroSchemaFailure(a)
+            }
+        }
         .rethrow
     }
   }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/producer/AvroRecord.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/producer/AvroRecord.scala
@@ -24,7 +24,8 @@ object AvroRecord {
       schema: Schema,
       key: Option[String],
       json: String,
-      ackStrategy: AckStrategy
+      ackStrategy: AckStrategy,
+      useStrictValidation: Boolean = false
   ): AvroRecord = {
 
     val payload: GenericRecord = {

--- a/ingestors/kafka/src/main/scala/hydra/kafka/producer/AvroRecord.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/producer/AvroRecord.scala
@@ -30,7 +30,7 @@ object AvroRecord {
 
     val payload: GenericRecord = {
       val converter: JsonConverter[GenericRecord] =
-        new JsonConverter[GenericRecord](schema)
+        new JsonConverter[GenericRecord](schema, useStrictValidation)
       converter.convert(json)
     }
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -102,7 +102,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
   ): F[Unit] = {
     val message = createTopicRequest.toKeyAndValue
     for {
-      records <- TopicMetadataV2.encode[F](message._1, message._2)
+      records <- TopicMetadataV2.encode[F](message._1, Some(message._2))
       _ <- kafkaClient
         .publishMessage(records, v2MetadataTopicName.value)
         .rethrow

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaClientAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaClientAlgebraSpec.scala
@@ -53,7 +53,7 @@ class KafkaClientAlgebraSpec
 
   private def runTest(schemaRegistry: SchemaRegistry[IO], kafkaClient: KafkaClientAlgebra[IO], isTest: Boolean = false): Unit = {
     (if (isTest) "KafkaClient#test" else "KafkaClient#live") must {
-      "publish message to kafka" in {
+      "publish avro message to kafka" in {
         val (topic, key, value) = topicAndKeyAndValue("topic1","key1","value1")
         (schemaRegistry.registerSchema(subject = s"$topic-key", key.getSchema) *>
           schemaRegistry.registerSchema(subject = s"$topic-value", value.getSchema) *>
@@ -62,21 +62,21 @@ class KafkaClientAlgebraSpec
       }
 
       val (topic, key, value) = topicAndKeyAndValue("topic1","key1","value1")
-      "consume message from kafka" in {
+      "consume avro message from kafka" in {
         val records = kafkaClient.consumeMessages(topic,"newConsumerGroup").take(1).compile.toList.unsafeRunSync()
         records should have length 1
         records.head shouldBe (key, value)
       }
 
       val (_, key2, value2) = topicAndKeyAndValue("topic1","key2","value2")
-      "publish a record to existing topic and consume only that value in existing consumer group" in {
+      "publish avro record to existing topic and consume only that value in existing consumer group" in {
         kafkaClient.publishMessage((key2, value2), topic).unsafeRunSync()
         val records = kafkaClient.consumeMessages(topic, "newConsumerGroup6").take(2).compile.toList.unsafeRunSync()
         records should contain allOf((key2, value2), (key, value))
       }
 
       val (_, key3, value3) = topicAndKeyAndValue("topic1","key3","value3")
-      "continue consuming messages from the same stream" in {
+      "continue consuming avro messages from the same stream" in {
         val stream = kafkaClient.consumeMessages(topic, "doesNotReallyMatter")
         stream.take(2).compile.toList.unsafeRunSync() should contain allOf((key2, value2), (key, value))
         kafkaClient.publishMessage((key3, value3), topic).unsafeRunSync()
@@ -85,7 +85,7 @@ class KafkaClientAlgebraSpec
 
       val (topic2, key4, value4) = topicAndKeyAndValue("topic2","key4","value4")
       val (_, key5, value5) = topicAndKeyAndValue("topic2","key5","value5")
-      "consume from two different topics" in {
+      "consume avro messages from two different topics" in {
         (schemaRegistry.registerSchema(subject = s"$topic2-key", key4.getSchema) *>
           schemaRegistry.registerSchema(subject = s"$topic2-value", value4.getSchema) *>
           kafkaClient.publishMessage((key4, value4), topic2) *>

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaClientAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaClientAlgebraSpec.scala
@@ -72,7 +72,7 @@ class KafkaClientAlgebraSpec
     "consume avro message from kafka" in {
       val records = kafkaClient.consumeMessages(topic,"newConsumerGroup").take(1).compile.toList.unsafeRunSync()
       records should have length 1
-      records.head shouldBe (key, value)
+      records.head shouldBe (key, Some(value))
     }
 
     val (_, (_, key2), value2) = topicAndKeyAndValue("topic1","key2","value2")

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/MetadataAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/MetadataAlgebraSpec.scala
@@ -63,7 +63,7 @@ class MetadataAlgebraSpec extends AnyWordSpecLike with Matchers {
           _ <- kafkaClientAlgebra.publishMessage(record, metadataTopicName)
           _ <- metadataAlgebra.getMetadataFor(subject).retryIfFalse(_.isDefined)
           metadata <- metadataAlgebra.getMetadataFor(subject)
-        } yield metadata shouldBe Some(TopicMetadataV2Container(key, value))).unsafeRunSync()
+        } yield metadata shouldBe Some(TopicMetadataV2Container(key, Some(value)))).unsafeRunSync()
       }
 
       "retrieve all metadata" in {
@@ -79,7 +79,7 @@ class MetadataAlgebraSpec extends AnyWordSpecLike with Matchers {
     }
   }
 
-  private def getMetadataGenericRecords(subject: Subject): (IO[(GenericRecord, GenericRecord)], TopicMetadataV2Key, TopicMetadataV2Value) = {
+  private def getMetadataGenericRecords(subject: Subject): (IO[(GenericRecord, Option[GenericRecord])], TopicMetadataV2Key, TopicMetadataV2Value) = {
     val key = TopicMetadataV2Key(subject)
     val value = TopicMetadataV2Value(
         History,
@@ -89,6 +89,6 @@ class MetadataAlgebraSpec extends AnyWordSpecLike with Matchers {
         Instant.now,
         List(),
         None)
-    (TopicMetadataV2.encode[IO](key, value), key, value)
+    (TopicMetadataV2.encode[IO](key, Some(value)), key, value)
   }
 }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/marshallers/TopicMetadataV2AdapterSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/marshallers/TopicMetadataV2AdapterSpec.scala
@@ -17,7 +17,7 @@ class TopicMetadataV2AdapterSpec extends AnyWordSpec with Matchers with TopicMet
       val date = Instant.now
       val key = TopicMetadataV2Key(Subject.createValidated("mySubjectHere").get)
       val value = TopicMetadataV2Value(History, deprecated = false, Public, NonEmptyList.one(Slack.create("#channel").get), date, List(), None)
-      val container = TopicMetadataV2Container(key, value)
+      val container = TopicMetadataV2Container(key, Some(value))
 
       toResource(container).compactPrint shouldBe s"""{"_links":{"self":{"href":"/v2/streams/mySubjectHere"},"hydra-schema":{"href":"/v2/schemas/mySubjectHere"}},"key":{"subject":"mySubjectHere"},"value":{"contact":{"slackChannel":"#channel"},"createdDate":"${date.toString}","dataClassification":"Public","deprecated":false,"parentSubjects":[],"streamType":"History"}}"""
     }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
@@ -54,7 +54,7 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
     )
 
     val (encodedKey, encodedValue) =
-      TopicMetadataV2.encode[IO](key, value).unsafeRunSync()
+      TopicMetadataV2.encode[IO](key, Some(value)).unsafeRunSync()
 
     encodedKey shouldBe new GenericRecordBuilder(
       TopicMetadataV2Key.codec.schema.toOption.get
@@ -98,7 +98,7 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
     )
 
     val (encodedKey, encodedValue) =
-      TopicMetadataV2.encode[IO](key, value).unsafeRunSync()
+      TopicMetadataV2.encode[IO](key, Some(value)).unsafeRunSync()
 
     val (decodedKey,decodedValue) =
       TopicMetadataV2.decode[IO](encodedKey, encodedValue).unsafeRunSync()

--- a/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
@@ -82,7 +82,7 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
     val valueRecord =
       new GenericDatumReader[Any](valueSchema).read(null, decoder)
 
-    encodedValue shouldBe valueRecord
+    encodedValue shouldBe Some(valueRecord)
   }
 
   it must "encode and decode metadataV2" in {
@@ -104,6 +104,6 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
       TopicMetadataV2.decode[IO](encodedKey, encodedValue).unsafeRunSync()
 
     decodedKey shouldBe key
-    decodedValue shouldBe value
+    decodedValue shouldBe Some(value)
   }
 }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
@@ -10,7 +10,7 @@ import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
 import hydra.core.marshallers.History
 import hydra.kafka.algebras.KafkaAdminAlgebra.{Topic, TopicName}
-import hydra.kafka.algebras.KafkaClientAlgebra.PublishError
+import hydra.kafka.algebras.KafkaClientAlgebra.{ConsumerGroup, PublishError}
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra}
 import hydra.kafka.model.ContactMethod.Email
 import hydra.kafka.model.TopicMetadataV2Request.Subject
@@ -363,6 +363,8 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
     override def consumeMessages(topicName: TopicName, consumerGroup: String): fs2.Stream[IO, (GenericRecord, GenericRecord)] = fs2.Stream.empty
 
     override def publishStringKeyMessage(record: (String, GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
+
+    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (String, GenericRecord)] = ???
   }
 
   private def getSchema(name: String): Schema =

--- a/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
@@ -15,6 +15,7 @@ import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra}
 import hydra.kafka.model.ContactMethod.Email
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import hydra.kafka.model._
+import hydra.kafka.producer.StringRecord
 import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -362,9 +363,9 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
 
     override def consumeMessages(topicName: TopicName, consumerGroup: String): fs2.Stream[IO, (GenericRecord, GenericRecord)] = fs2.Stream.empty
 
-    override def publishStringKeyMessage(record: (String, GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
+    override def publishStringKeyMessage(record: (Option[String], GenericRecord), topicName: TopicName): IO[Either[PublishError, Unit]] = ???
 
-    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (String, GenericRecord)] = ???
+    override def consumeStringKeyMessages(topicName: TopicName, consumerGroup: ConsumerGroup): fs2.Stream[IO, (Option[String], GenericRecord)] = ???
   }
 
   private def getSchema(name: String): Schema =


### PR DESCRIPTION
This PR will introduce complete feature parity between the new ingestion flow and the old one. The responses should all be identical, but the flow itself should be more reliable.
Some elements will still be sent to the old ingestion flow. These are specifically for supporting alternate ingestor types that may be looked up at runtime using reflection.
If one would like to use the old ingest flow, this can be accomplished by setting the `HYDRA_INGEST_ALTERNATE_IGNORE_UA_STRINGS` env variable. This is to be set as a list of strings like:

`one,two,three`

Any strings in that list will be ignored by the new ingest flow and sent to the old one instead.
