### PR TITLE
Add support for fetching all schemas with a single request

### DIFF
--- a/avro/src/main/scala/hydra/avro/resource/SchemaResourceLoader.scala
+++ b/avro/src/main/scala/hydra/avro/resource/SchemaResourceLoader.scala
@@ -62,6 +62,12 @@ class SchemaResourceLoader(
     else loadFromCache(subject.withKeySuffix, version.toString)
   }.map(_.getOrElse(throw SchemaRegistryException(SchemaNotFoundException(subject), subject)))
 
+  def retrieveValueSchemas(subjects: List[String])(
+      implicit ec: ExecutionContext
+  ): Future[List[(String, Option[SchemaResource])]] = {
+    Future.sequence(subjects.map(sub => getLatestSchema(sub.withValueSuffix).map(sch => (sub,sch))))
+  }
+
   def loadValueSchemaIntoCache(
       schemaResource: SchemaResource
   )(implicit ec: ExecutionContext): Future[SchemaResource] = {

--- a/avro/src/test/scala/hydra/avro/resource/SchemaResourceLoaderSpec.scala
+++ b/avro/src/test/scala/hydra/avro/resource/SchemaResourceLoaderSpec.scala
@@ -74,6 +74,18 @@ class SchemaResourceLoaderSpec
   }
 
   describe("When loading schemas from the registry") {
+
+    it("return a list of schemas") {
+      val loader = fixture()
+      val res = loader.retrieveValueSchemas(List(subject, subject))
+      whenReady(res) { metadatas =>
+        metadatas.map(_ match {
+          case (subj, Some(schemaResource)) => (subj, schemaResource.schema)
+          case _ => None
+        }) shouldBe List((subject,testValueSchema), (subject, testValueSchema))
+      }
+    }
+
     it("returns the latest version of a value schema") {
       val loader = fixture()
       val res = loader.retrieveValueSchema(subject)

--- a/core/src/test/scala/hydra/core/akka/SchemaRegistryActorSpec.scala
+++ b/core/src/test/scala/hydra/core/akka/SchemaRegistryActorSpec.scala
@@ -125,6 +125,18 @@ class SchemaRegistryActorSpec
     listener.expectNoMessage(3.seconds)
   }
 
+  it should "respond with FetchSchemasResponse" in {
+    val (probe, schemaRegistryActor) = fixture
+    schemaRegistryActor.tell(FetchSchemasRequest(List("hydra.test.Tester", "hydra.test.TesterWithKey")), probe.ref)
+    probe.expectMsgPF() {
+      case FetchSchemasResponse(valueSchemas) =>
+        valueSchemas shouldBe List(
+          ("hydra.test.Tester", Option(SchemaResource(1, 1, testSchema))),
+          ("hydra.test.TesterWithKey", Option(SchemaResource(1, 1, testSchema)))
+        )
+    }
+  }
+
   it should "respond with FetchSchemaResponse with a key" in {
     val (probe, schemaRegistryActor) = fixture
 

--- a/ingest/src/main/scala/hydra.ingest/http/SchemasEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/SchemasEndpoint.scala
@@ -64,19 +64,9 @@ class SchemasEndpoint(consumerProxy: ActorSelection)(implicit system: ActorSyste
   implicit val endpointFormat: RootJsonFormat[SchemasEndpointResponse] = jsonFormat3(SchemasEndpointResponse.apply)
   implicit val v2EndpointFormat: RootJsonFormat[SchemasWithKeyEndpointResponse] = jsonFormat2(SchemasWithKeyEndpointResponse.apply)
   implicit val schemasWithTopicFormat: RootJsonFormat[SchemasWithTopicResponse] = jsonFormat2(SchemasWithTopicResponse.apply)
-  implicit object batchSchemasFormat extends RootJsonFormat[BatchSchemasResponse] {
-    override def write(obj: BatchSchemasResponse): JsValue = {
-      val s = obj.schemasResponse.map(sch => schemasWithTopicFormat.write(sch))
-      JsObject(Map[String, JsValue](
-        "schemasResponse" -> JsArray(s.toVector)
-      ))
-    }
-
-    override def read(json: JsValue): BatchSchemasResponse = json match {
-      case j: JsObject =>
-        val schemasResponse = j.getFields("schemasResponse").headOption.map(_.convertTo[Vector[SchemasWithTopicResponse]]).get
-        BatchSchemasResponse(schemasResponse.toList)
-    }
+  implicit val batchSchemasFormat: RootJsonFormat[BatchSchemasResponse] = {
+    val make: List[SchemasWithTopicResponse] => BatchSchemasResponse = BatchSchemasResponse.apply
+    jsonFormat1(make)
   }
   implicit val timeout: Timeout = Timeout(3.seconds)
 

--- a/ingest/src/main/scala/hydra.ingest/http/SchemasEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/SchemasEndpoint.scala
@@ -16,7 +16,7 @@
 
 package hydra.ingest.http
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSelection, ActorSystem}
 import akka.http.javadsl.server.PathMatcher1
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Location
@@ -26,15 +26,26 @@ import akka.util.Timeout
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import hydra.avro.resource.SchemaResource
 import hydra.common.config.ConfigSupport
+import hydra.common.config.ConfigSupport._
 import hydra.core.akka.SchemaRegistryActor
 import hydra.core.akka.SchemaRegistryActor._
 import hydra.core.http.{CorsSupport, RouteSupport}
 import hydra.core.marshallers.GenericServiceResponse
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
 import org.apache.avro.SchemaParseException
-import spray.json.RootJsonFormat
+import spray.json.{JsArray, JsObject, JsValue, RootJsonFormat}
 import hydra.core.monitor.HydraMetrics.addPromHttpMetric
+import hydra.kafka.consumer.KafkaConsumerProxy.{ListTopics, ListTopicsResponse}
+import org.apache.kafka.common.PartitionInfo
+import scalacache.cachingF
+import scalacache._
+import scalacache.guava.GuavaCache
+import scalacache.modes.scalaFuture._
+import akka.http.scaladsl.server.ExceptionHandler
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.immutable.Map
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
@@ -42,17 +53,42 @@ import scala.concurrent.duration._
   *
   * Created by alexsilva on 2/13/16.
   */
-class SchemasEndpoint()(implicit system: ActorSystem)
+class SchemasEndpoint(consumerProxy: ActorSelection)(implicit system: ActorSystem)
     extends RouteSupport
     with ConfigSupport
     with CorsSupport {
 
+  private implicit val cache = GuavaCache[Map[String, Seq[PartitionInfo]]]
+
+
   implicit val endpointFormat: RootJsonFormat[SchemasEndpointResponse] = jsonFormat3(SchemasEndpointResponse.apply)
   implicit val v2EndpointFormat: RootJsonFormat[SchemasWithKeyEndpointResponse] = jsonFormat2(SchemasWithKeyEndpointResponse.apply)
+  implicit val schemasWithTopicFormat: RootJsonFormat[SchemasWithTopicResponse] = jsonFormat2(SchemasWithTopicResponse.apply)
+  implicit object batchSchemasFormat extends RootJsonFormat[BatchSchemasResponse] {
+    override def write(obj: BatchSchemasResponse): JsValue = {
+      val s = obj.schemasResponse.map(sch => schemasWithTopicFormat.write(sch))
+      JsObject(Map[String, JsValue](
+        "schemasResponse" -> JsArray(s.toVector)
+      ))
+    }
+
+    override def read(json: JsValue): BatchSchemasResponse = json match {
+      case j: JsObject =>
+        val schemasResponse = j.getFields("schemasResponse").headOption.map(_.convertTo[Vector[SchemasWithTopicResponse]]).get
+        BatchSchemasResponse(schemasResponse.toList)
+    }
+  }
   implicit val timeout: Timeout = Timeout(3.seconds)
 
   private val schemaRegistryActor =
     system.actorOf(SchemaRegistryActor.props(applicationConfig))
+
+  private val filterSystemTopics = (t: String) =>
+    (t.startsWith("_") && showSystemTopics) || !t.startsWith("_")
+
+  private val showSystemTopics = applicationConfig
+    .getBooleanOpt("transports.kafka.show-system-topics")
+    .getOrElse(false)
 
   override def route: Route = cors(settings) {
     handleExceptions(excptHandler) {
@@ -102,6 +138,15 @@ class SchemasEndpoint()(implicit system: ActorSystem)
   private val v2Route =
     pathPrefix("v2") {
       get {
+        pathPrefix("schemas") {
+          pathEndOrSingleSlash {
+            extractExecutionContext { implicit ec =>
+              onSuccess(topics) { topics =>
+                getSchemas(topics.keys.toList)
+              }
+            }
+          }
+        } ~
         pathPrefix("schemas" / Segment) { subject =>
           pathEndOrSingleSlash {
             getSchema(includeKeySchema = true, subject, None)
@@ -127,6 +172,19 @@ class SchemasEndpoint()(implicit system: ActorSystem)
             .getOrElse {
               complete(OK, SchemasEndpointResponse(schemaResource))
             }
+        }
+      }
+    }
+  }
+
+  def getSchemas(subjects: List[String]): Route = {
+    onSuccess(
+      (schemaRegistryActor ? FetchSchemasRequest(subjects))
+        .mapTo[FetchSchemasResponse]
+    ) {
+      response => {
+        extractExecutionContext { implicit ec =>
+          complete(OK, BatchSchemasResponse.apply(response))
         }
       }
     }
@@ -204,6 +262,18 @@ class SchemasEndpoint()(implicit system: ActorSystem)
         }
       }
   }
+
+  private def topics(implicit ec: ExecutionContext): Future[Map[String, Seq[PartitionInfo]]] = {
+    implicit val timeout = Timeout(5 seconds)
+    cachingF("topics")(ttl = Some(1.minute)) {
+      import akka.pattern.ask
+      (consumerProxy ? ListTopics).mapTo[ListTopicsResponse].map { response =>
+        response.topics.filter(t => filterSystemTopics(t._1)).map {
+          case (k, v) => k -> v.toList
+        }
+      }
+    }
+  }
 }
 
 case class SchemasWithKeyEndpointResponse(keySchemaResponse: Option[SchemasEndpointResponse], valueSchemaResponse: SchemasEndpointResponse)
@@ -214,6 +284,20 @@ object SchemasWithKeyEndpointResponse {
       f.keySchemaResource.map(SchemasEndpointResponse.apply),
       SchemasEndpointResponse.apply(f.schemaResource)
     )
+}
+
+case class SchemasWithTopicResponse(topic: String, valueSchemaResponse: Option[SchemasEndpointResponse])
+
+object SchemasWithTopicResponse {
+  def apply(t: (String, Option[SchemaResource])): SchemasWithTopicResponse =
+    new SchemasWithTopicResponse(t._1, t._2.map(SchemasEndpointResponse.apply))
+}
+
+case class BatchSchemasResponse(schemasResponse: List[SchemasWithTopicResponse])
+
+object BatchSchemasResponse {
+  def apply(f: FetchSchemasResponse) =
+    new BatchSchemasResponse(f.valueSchemas.map(SchemasWithTopicResponse.apply))
 }
 
 case class SchemasEndpointResponse(id: Int, version: Int, schema: String)

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -41,7 +41,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
 
     val consumerProxy = system.actorSelection(consumerPath)
 
-    new SchemasEndpoint().route ~
+    new SchemasEndpoint(consumerProxy).route ~
       new BootstrapEndpoint(system).route ~
       new TopicMetadataEndpoint(consumerProxy, algebras.metadata).route ~
       new IngestorRegistryEndpoint().route ~

--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -22,6 +22,12 @@ hydra_test {
   transports {
     test.message = "HELLO!"
   }
+
+  actors {
+      kafka {
+        consumer_proxy.path = "/user/kafka_consumer_proxy_test"
+      }
+    }
 }
 
 akka {

--- a/ingest/src/test/scala/hydra/ingest/http/SchemasEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/SchemasEndpointSpec.scala
@@ -59,19 +59,9 @@ class SchemasEndpointSpec
   implicit val endpointFormat = jsonFormat3(SchemasEndpointResponse.apply)
   implicit val endpointV2Format = jsonFormat2(SchemasWithKeyEndpointResponse.apply)
   implicit val schemasWithTopicFormat: RootJsonFormat[SchemasWithTopicResponse] = jsonFormat2(SchemasWithTopicResponse.apply)
-  implicit object batchSchemasFormat extends RootJsonFormat[BatchSchemasResponse] {
-    override def write(obj: BatchSchemasResponse): JsValue = {
-      val s = obj.schemasResponse.map(sch => schemasWithTopicFormat.write(sch))
-      JsObject(Map[String, JsValue](
-        "schemasResponse" -> JsArray(s.toVector)
-      ))
-    }
-
-    override def read(json: JsValue): BatchSchemasResponse = json match {
-      case j: JsObject =>
-        val schemasResponse = j.getFields("schemasResponse").headOption.map(_.convertTo[Vector[SchemasWithTopicResponse]]).get
-        BatchSchemasResponse(schemasResponse.toList)
-    }
+  implicit val batchSchemasFormat: RootJsonFormat[BatchSchemasResponse] = {
+    val make: List[SchemasWithTopicResponse] => BatchSchemasResponse = BatchSchemasResponse.apply
+    jsonFormat1(make)
   }
 
   private val schemaRegistry =

--- a/ingest/src/test/scala/hydra/ingest/http/SchemasEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/SchemasEndpointSpec.scala
@@ -1,18 +1,29 @@
 package hydra.ingest.http
 
-import akka.actor.ActorSystem
+import akka.actor.{Actor, ActorRef, ActorSelection, ActorSystem, Props}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestKit
+import cats.effect.IO
 import com.typesafe.config.ConfigFactory
-import hydra.avro.registry.ConfluentSchemaRegistry
+import hydra.avro.registry.{ConfluentSchemaRegistry, SchemaRegistry}
 import hydra.common.config.ConfigSupport
+import hydra.common.util.ActorUtils
 import hydra.core.marshallers.{GenericServiceResponse, HydraJsonSupport}
 import hydra.ingest.http.mock.MockEndpoint
+import hydra.kafka.algebras.{KafkaClientAlgebra, MetadataAlgebra}
+import hydra.kafka.consumer.KafkaConsumerProxy
+import hydra.kafka.consumer.KafkaConsumerProxy.{GetPartitionInfo, ListTopics, ListTopicsResponse, PartitionInfoResponse}
+import hydra.kafka.endpoints.{CreateTopicReq, CreateTopicResponseError, TopicMetadataEndpoint}
+import hydra.kafka.marshallers.HydraKafkaJsonSupport
 import org.apache.avro.Schema
+import org.apache.kafka.common.{Node, PartitionInfo}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import spray.json.{JsArray, JsObject, JsValue, RootJsonFormat}
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 
+import scala.collection.immutable.Map
 import scala.concurrent.duration._
 import scala.io.Source
 
@@ -24,15 +35,44 @@ class SchemasEndpointSpec
     with AnyWordSpecLike
     with ScalatestRouteTest
     with HydraJsonSupport
-    with ConfigSupport {
+    with HydraKafkaJsonSupport
+    with ConfigSupport
+    with EmbeddedKafka {
+
+  import ConfigSupport._
+
+  implicit val kafkaConfig: EmbeddedKafkaConfig =
+    EmbeddedKafkaConfig(kafkaPort = 8092, zooKeeperPort = 3181)
 
   override def createActorSystem(): ActorSystem =
     ActorSystem(actorSystemNameFrom(getClass))
 
-  val schemasRoute = new SchemasEndpoint().route
+  val consumerPath: String = applicationConfig
+    .getStringOpt("actors.kafka.consumer_proxy.path")
+    .getOrElse(
+      s"/user/service/${ActorUtils.actorName(classOf[KafkaConsumerProxy])}"
+    )
+
+  val consumerProxy: ActorSelection = system.actorSelection(consumerPath)
+
+  val schemasRoute = new SchemasEndpoint(consumerProxy).route
   implicit val endpointFormat = jsonFormat3(SchemasEndpointResponse.apply)
   implicit val endpointV2Format = jsonFormat2(SchemasWithKeyEndpointResponse.apply)
+  implicit val schemasWithTopicFormat: RootJsonFormat[SchemasWithTopicResponse] = jsonFormat2(SchemasWithTopicResponse.apply)
+  implicit object batchSchemasFormat extends RootJsonFormat[BatchSchemasResponse] {
+    override def write(obj: BatchSchemasResponse): JsValue = {
+      val s = obj.schemasResponse.map(sch => schemasWithTopicFormat.write(sch))
+      JsObject(Map[String, JsValue](
+        "schemasResponse" -> JsArray(s.toVector)
+      ))
+    }
 
+    override def read(json: JsValue): BatchSchemasResponse = json match {
+      case j: JsObject =>
+        val schemasResponse = j.getFields("schemasResponse").headOption.map(_.convertTo[Vector[SchemasWithTopicResponse]]).get
+        BatchSchemasResponse(schemasResponse.toList)
+    }
+  }
 
   private val schemaRegistry =
     ConfluentSchemaRegistry.forConfig(applicationConfig)
@@ -43,8 +83,14 @@ class SchemasEndpointSpec
   val schemaEvolved =
     new Schema.Parser().parse(Source.fromResource("schema2.avsc").mkString)
 
+  val newSchema =
+    new Schema.Parser().parse(Source.fromResource("schema-new.avsc").mkString)
+
+
   override def beforeAll = {
     super.beforeAll()
+    EmbeddedKafka.start()
+
     Post("/schemas", schema.toString) ~> schemasRoute ~> check {
       response.status.intValue() shouldBe 201
       val r = responseAs[SchemasEndpointResponse]
@@ -58,16 +104,53 @@ class SchemasEndpointSpec
       new Schema.Parser().parse(r.schema) shouldBe schemaEvolved
       r.version shouldBe 2
     }
+
+    Post("/schemas", newSchema.toString) ~> schemasRoute ~> check {
+      response.status.intValue() shouldBe 201
+      val r = responseAs[SchemasEndpointResponse]
+      new Schema.Parser().parse(r.schema) shouldBe newSchema
+      r.version shouldBe 1
+    }
   }
 
   override def afterAll = {
     super.afterAll()
+    EmbeddedKafka.stop()
     TestKit.shutdownActorSystem(
       system,
       verifySystemShutdown = true,
       duration = 10 seconds
     )
   }
+
+  val node = new Node(0, "host", 1)
+
+  def partitionInfo(name: String) =
+    new PartitionInfo(name, 0, node, Array(node), Array(node))
+
+  val topics = Map(
+    "hydra.test.Tester" -> Seq(partitionInfo("hydra.test.Tester")),
+    "hydra.test.NewTester" -> Seq(partitionInfo(name="hydra.test.NewTester"))
+  )
+
+  private implicit val createTopicFormat: RootJsonFormat[CreateTopicReq] = jsonFormat4(CreateTopicReq)
+
+  private implicit val errorFormat: RootJsonFormat[CreateTopicResponseError] = jsonFormat1(CreateTopicResponseError)
+
+  val proxy: ActorRef = system.actorOf(
+    Props(new Actor {
+
+      override def receive: Receive = {
+        case ListTopics =>
+          sender ! ListTopicsResponse(topics)
+        case GetPartitionInfo(topic) =>
+          sender ! PartitionInfoResponse(topic, Seq(partitionInfo(topic)))
+        case x =>
+          throw new RuntimeException(s"did not expect $x")
+      }
+    }),
+    "kafka_consumer_proxy_test"
+  )
 
   "The schemas endpoint" should {
 
@@ -161,5 +244,20 @@ class SchemasEndpointSpec
       }
     }
 
+    "return schemas" in {
+      Get("/v2/schemas") ~> schemasRoute ~> check {
+        val resp = responseAs[BatchSchemasResponse]
+
+        resp.schemasResponse.length shouldBe 2
+        val schemaResp1 = resp.schemasResponse.head
+        val schemaResp2 = resp.schemasResponse.tail.head
+
+        schemaResp1.topic shouldBe "hydra.test.Tester"
+        schemaResp1.valueSchemaResponse.get.schema shouldBe schemaEvolved.toString
+
+        schemaResp2.topic shouldBe "hydra.test.NewTester"
+        schemaResp2.valueSchemaResponse.get.schema shouldBe newSchema.toString
+      }
+    }
   }
 }

--- a/ingest/src/test/scala/hydra/ingest/http/mock/MockEndpoint.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/mock/MockEndpoint.scala
@@ -1,10 +1,13 @@
 package hydra.ingest.http.mock
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSelection, ActorSystem}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
+import hydra.common.config.ConfigSupport
+import hydra.common.util.ActorUtils
 import hydra.ingest.http.SchemasEndpoint
+import hydra.kafka.consumer.KafkaConsumerProxy
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,7 +15,17 @@ import scala.concurrent.{ExecutionContext, Future}
 class MockEndpoint(
     implicit system: ActorSystem,
     implicit val e: ExecutionContext
-) {
+) extends ConfigSupport {
+
+  import ConfigSupport._
+
+  val consumerPath: String = applicationConfig
+    .getStringOpt("actors.kafka.consumer_proxy.path")
+    .getOrElse(
+      s"/user/service/${ActorUtils.actorName(classOf[KafkaConsumerProxy])}"
+    )
+
+  val consumerProxy: ActorSelection = system.actorSelection(consumerPath)
 
   def throwRestClientException(
       statusCode: Int,
@@ -23,7 +36,7 @@ class MockEndpoint(
   }
 
   val schemaRouteExceptionHandler: ExceptionHandler =
-    new SchemasEndpoint().excptHandler
+    new SchemasEndpoint(consumerProxy).excptHandler
 
   def route: Route = {
     pathPrefix("throwRestClientException") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -198,7 +198,7 @@ object Dependencies {
     ) ++ guavacache ++
     confluent ++ kamon
 
-  val ingestDeps: Seq[ModuleID] = coreDeps ++ akkaHttpHal ++ Seq(ciris)
+  val ingestDeps: Seq[ModuleID] = coreDeps ++ akkaHttpHal ++ Seq(ciris, embeddedKafka)
 
   val kafkaDeps: Seq[ModuleID] = coreDeps ++ Seq(
     akkaKafkaStream,


### PR DESCRIPTION
The approach here is that a request is sent with no params and the handler will go and fetch all thye topic names the same way that the TopicMetadataEndpoint does it and then pass that list of names to the SchemaRegistryActor and it will fetch each one. 

The response will be a list of objects with the topic name and the value schema. Including the topic name is necessary so it can be combined with the metadata on the frontend. Example output below.

If a schema for a topic is found then it should just return an empty object for the schema instead of throwing an error. In the frontend we can display that we were unable to get the schema.

<img width="1276" alt="Screen Shot 2020-08-06 at 12 48 09 PM" src="https://user-images.githubusercontent.com/6674580/89570214-1cdcc580-d7e3-11ea-8ccb-8d66735d2445.png">
