### PR TITLE
Feature/add programmatic topic deletion

### DIFF
--- a/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
+++ b/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
@@ -6,6 +6,7 @@ import org.apache.avro.{Schema, SchemaValidatorBuilder}
 import cats.syntax.all._
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityChecker
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
+import javax.security.auth.Subject
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -37,6 +38,11 @@ trait SchemaRegistry[F[_]] {
     * @return Unit
     */
   def deleteSchemaOfVersion(subject: String, version: SchemaVersion): F[Unit]
+
+  /**
+    * blah fill in
+    */
+  def deleteSchemaSubject(subject: String): F[Unit]
 
   /**
     * Retrieves the SchemaVersion if the given subject and schema match an item in SchemaRegistry.
@@ -150,6 +156,8 @@ object SchemaRegistry {
           schemaRegistryClient.deleteSchemaVersion(subject, version.toString)
         )
 
+
+
       override def getVersion(
           subject: String,
           schema: Schema
@@ -185,6 +193,13 @@ object SchemaRegistry {
         }.toOption
       }
 
+      /**
+        * blah fill in
+        */
+      override def deleteSchemaSubject(subject: String): F[Unit] =
+        Sync[F].delay {
+          schemaRegistryClient.deleteSubject(subject)
+        }
     }
 
 }

--- a/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
+++ b/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
@@ -40,7 +40,10 @@ trait SchemaRegistry[F[_]] {
   def deleteSchemaOfVersion(subject: String, version: SchemaVersion): F[Unit]
 
   /**
-    * blah fill in
+    * Deletes the subject from the versionCache, idCache, and schemaCache
+    * of the CachedSchemaRegistryClient
+    * @param subject The subject using -key or -value to delete
+    * @return Unit
     */
   def deleteSchemaSubject(subject: String): F[Unit]
 
@@ -193,9 +196,6 @@ object SchemaRegistry {
         }.toOption
       }
 
-      /**
-        * blah fill in
-        */
       override def deleteSchemaSubject(subject: String): F[Unit] =
         Sync[F].delay {
           schemaRegistryClient.deleteSubject(subject)

--- a/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
@@ -97,17 +97,25 @@ object AppConfig {
       env("HYDRA_INGEST_RECORD_SIZE_LIMIT_BYTES").as[Long].option
     ).parMapN(IngestConfig)
 
+  final case class TopicDeletionConfig(deleteTopicPassword: String)
+
+  private val topicDeletionConfig: ConfigValue[TopicDeletionConfig] =
+    (
+      env("HYDRA_INGEST_TOPIC_DELETION_PASSWORD").as[String].default("")
+    ).map(TopicDeletionConfig)
+
   final case class AppConfig(
       createTopicConfig: CreateTopicConfig,
       v2MetadataTopicConfig: V2MetadataTopicConfig,
-      ingestConfig: IngestConfig
+      ingestConfig: IngestConfig,
+      topicDeletionConfig: TopicDeletionConfig
   )
 
   val appConfig: ConfigValue[AppConfig] =
     (
       createTopicConfig,
       v2MetadataTopicConfig,
-      ingestConfig
+      ingestConfig,
+      topicDeletionConfig
     ).parMapN(AppConfig)
-
 }

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -3,7 +3,8 @@ package hydra.ingest.http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
-import hydra.ingest.programs.TopicDeletionProgram
+import cats.data.Validated
+import hydra.ingest.programs.{DeleteTopicError, DeleteTopicErrors, SchemaDeletionErrors, TopicDeletionProgram}
 import hydra.common.util.Futurable
 import hydra.core.http.RouteSupport
 import spray.json.DefaultJsonProtocol
@@ -27,25 +28,29 @@ final class TopicDeletionEndpoint[F[_]: Futurable] (deletionProgram: TopicDeleti
               // check if consumers exist for this topic, if they do fail and return consumer groups
               // try deleting topic
 
-              val maybeDeletion = deletionProgram.deleteTopic(maybeList)
-              if(maybeDeletion.isLeft) {
-                if (maybeDeletion.left.get.errors.length == maybeList.length) {
-                  complete(StatusCodes.InternalServerError, maybeDeletion.left.get)
-                } else {
-                  complete(StatusCodes.PartialContent, maybeDeletion.left.get)
+              onComplete(
+                Futurable[F].unsafeToFuture(deletionProgram.deleteTopic(maybeList))
+              ) {
+                case Success(maybeSuccess) => {
+                  maybeSuccess match {
+                    case Validated.Valid(a) => {
+                      maybeList.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))
+                      complete(StatusCodes.OK)
+                    }
+                    case Validated.Invalid(e) => {
+                      e.asInstanceOf[DeleteTopicError] match {
+                        case SchemaDeletionErrors(schemaDeleteTopicErrorList) => {
+                          val badTopics = schemaDeleteTopicErrorList.errors.toList.map(error => error.subject.split("-").head)
+                          val goodTopics = maybeList.toSet.diff(badTopics.toSet).toList
+                          badTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.InternalServerError.toString(), "/deleteTopics/"))
+                          goodTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))
+                          complete(StatusCodes.Accepted, schemaDeleteTopicErrorList.errors.toList.map(error => error.errorMessage))
+                        }
+                      }
+                    }
+                  }
                 }
-              } else {
-                complete(StatusCodes.OK)
               }
-
-              // Confirm that topics are deleted?
-              // If one or more failed continue and put in list for partial completion or failure
-              // Call Schema registry and delete topic(s) that succeeded
-              // return partial success if at least one topic succeeded
-              // return failure if not topics succeeded
-              // return success if all topics succeeded
-//              maybeList.map(topic => addPromHttpMetric(topic, StatusCodes.OK.toString(), "/deleteTopics"))
-//              complete(StatusCodes.OK)
             }
           }
         }

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -8,7 +8,7 @@ import cats.data.Validated
 import hydra.ingest.programs.{KafkaDeletionErrors, SchemaDeletionErrors, TopicDeletionProgram}
 import hydra.common.util.Futurable
 import hydra.core.http.RouteSupport
-import spray.json.{DefaultJsonProtocol, JsArray, JsObject, JsValue, JsonFormat, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 import hydra.core.monitor.HydraMetrics.addPromHttpMetric
 
 import scala.concurrent.ExecutionContext
@@ -95,8 +95,6 @@ final class TopicDeletionEndpoint[F[_]: Futurable] (deletionProgram: TopicDeleti
               pathEndOrSingleSlash {
                 entity(as[DeletionRequest]) { req =>
                   val maybeList = req.topics
-                  // check if consumers exist for this topic, if they do fail and return consumer groups
-                  // try deleting topic
                   deleteTopics(maybeList, userName)
                 }
               }

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import cats.data.Validated
-import hydra.ingest.programs.{DeleteTopicError, DeleteTopicErrors, SchemaDeletionErrors, TopicDeletionProgram}
+import hydra.ingest.programs.{DeleteTopicError, SchemaDeletionErrors, TopicDeletionProgram}
 import hydra.common.util.Futurable
 import hydra.core.http.RouteSupport
 import spray.json.DefaultJsonProtocol

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -40,7 +40,7 @@ final class TopicDeletionEndpoint[F[_]: Futurable] (deletionProgram: TopicDeleti
                     case Validated.Invalid(e) => {
                       e.asInstanceOf[DeleteTopicError] match {
                         case SchemaDeletionErrors(schemaDeleteTopicErrorList) => {
-                          val badTopics = schemaDeleteTopicErrorList.errors.toList.map(error => error.subject.split("-").head)
+                          val badTopics = schemaDeleteTopicErrorList.errors.toList.map(error => error.errorMessage.split("-").head)
                           val goodTopics = maybeList.toSet.diff(badTopics.toSet).toList
                           badTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.InternalServerError.toString(), "/deleteTopics/"))
                           goodTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -1,0 +1,60 @@
+package hydra.ingest.http
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
+import cats.data.Validated
+import cats.implicits._
+import hydra.common.util.Futurable
+import hydra.core.http.RouteSupport
+import spray.json.DefaultJsonProtocol
+import hydra.core.monitor.HydraMetrics.addPromHttpMetric
+import hydra.kafka.algebras.KafkaAdminAlgebra
+
+import scala.util.{Failure, Success}
+
+final class TopicDeletionEndpoint[F[_]: Futurable] (kafkaClient: KafkaAdminAlgebra[F]) extends RouteSupport with DefaultJsonProtocol with SprayJsonSupport {
+
+  override val route: Route =
+    handleExceptions(exceptionHandler) {
+      path("deleteTopics" / Segment) { topic =>
+        extractExecutionContext { implicit ec =>
+          pathEndOrSingleSlash {
+            delete {
+              val maybeList = topic.split(",").toList
+              // check if consumers exist for this topic, if they do fail and return consumer groups
+              // try deleting topic
+
+              onComplete(
+                Futurable[F].unsafeToFuture(
+                  kafkaClient.deleteTopics(maybeList)
+                )
+              ) {
+                case Success(Right(_)) =>
+                case Success(Left(deletionErrors)) =>
+                case Failure(error) =>
+              }
+
+              // Confirm that topics are deleted?
+              // If one or more failed continue and put in list for partial completion or failure
+              // Call Schema registry and delete topic(s) that succeeded
+              // return partial success if at least one topic succeeded
+              // return failure if not topics succeeded
+              // return success if all topics succeeded
+//              maybeList.map(topic => addPromHttpMetric(topic, StatusCodes.OK.toString(), "/deleteTopics"))
+//              complete(StatusCodes.OK)
+            }
+          }
+        }
+      }
+    }
+
+  private def exceptionHandler = ExceptionHandler {
+    case e =>
+      extractExecutionContext{ implicit ec =>
+        addPromHttpMetric("", StatusCodes.InternalServerError.toString,"/deleteTopic")
+        complete(500, e.getMessage)
+      }
+  }
+
+}

--- a/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/TopicDeletionEndpoint.scala
@@ -4,13 +4,13 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import cats.data.Validated
-import hydra.ingest.programs.{DeleteTopicError, SchemaDeletionErrors, TopicDeletionProgram}
+import hydra.ingest.programs.{KafkaDeletionErrors, SchemaDeletionErrors, TopicDeletionProgram}
 import hydra.common.util.Futurable
 import hydra.core.http.RouteSupport
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, JsArray, JsObject, JsValue, JsonFormat, RootJsonFormat}
 import hydra.core.monitor.HydraMetrics.addPromHttpMetric
-import hydra.kafka.algebras.KafkaAdminAlgebra
 
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 final class TopicDeletionEndpoint[F[_]: Futurable] (deletionProgram: TopicDeletionProgram[F])
@@ -18,39 +18,92 @@ final class TopicDeletionEndpoint[F[_]: Futurable] (deletionProgram: TopicDeleti
     DefaultJsonProtocol with
     SprayJsonSupport {
 
+  implicit val endpointFormat = jsonFormat2(DeletionEndpointResponse.apply)
+  case class DeletionEndpointResponse(topicOrSubject: String, message: String)
+
+  private def tupleErrorsToResponse(errorTuple: (List[SchemaDeletionErrors], List[KafkaDeletionErrors])): List[DeletionEndpointResponse] = {
+    schemaErrorsToResponse(errorTuple._1) ::: kafkaErrorsToResponse(errorTuple._2)
+  }
+
+  private def schemaErrorsToResponse(schemaResults: List[SchemaDeletionErrors]): List[DeletionEndpointResponse] = {
+    schemaResults.flatMap(_.schemaDeleteTopicErrorList.errors.map(e => DeletionEndpointResponse(e.getSubject, e.errorMessage)).toList)
+  }
+
+  private def kafkaErrorsToResponse(kafkaResults: List[KafkaDeletionErrors]): List[DeletionEndpointResponse] = {
+    kafkaResults.flatMap(_.kafkaDeleteTopicErrorList.errors.map(e => DeletionEndpointResponse(e.topicName, e.errorMessage)).toList)
+  }
+
+  final case class DeletionRequest(valPayload: String)
+  private final case class IntermediateDeletionRequest(topics: JsArray)
+  private implicit val intermediateDeletionRequestFormat: JsonFormat[IntermediateDeletionRequest] =
+    jsonFormat1(IntermediateDeletionRequest)
+
+  implicit object DeletionRequestFormat extends RootJsonFormat[DeletionRequest] {
+    override def read(json: JsValue): DeletionRequest = {
+      val inter = intermediateDeletionRequestFormat.read(json)
+      DeletionRequest(inter.topics.compactPrint)
+    }
+
+    //Not implemented on purpose. Never used
+    override def write(obj: DeletionRequest): JsValue = ???
+  }
+
+  private def deleteTopics(topics: List[String])(implicit ec: ExecutionContext) = {
+    onComplete(
+      Futurable[F].unsafeToFuture(deletionProgram.deleteTopic(topics))
+    ) {
+      case Success(maybeSuccess) => {
+        maybeSuccess match {
+          case Validated.Valid(a) => {
+            topics.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))
+            complete(StatusCodes.OK, topics)
+          }
+          case Validated.Invalid(e) => {
+            val allErrors = e.foldLeft((List.empty[SchemaDeletionErrors], List.empty[KafkaDeletionErrors])) { (agg, i) =>
+              i match {
+                case sde: SchemaDeletionErrors => (agg._1 :+ sde, agg._2)
+                case kde: KafkaDeletionErrors => (agg._1, agg._2 :+ kde)
+              }
+            }
+            val response = tupleErrorsToResponse(allErrors)
+            if (response.length == topics.length) {
+              topics.map(topicName => addPromHttpMetric(topicName, StatusCodes.InternalServerError.toString(), "/deleteTopics/"))
+              complete(StatusCodes.InternalServerError, response)
+            } else {
+              response.map(der => addPromHttpMetric(der.topicOrSubject, StatusCodes.Accepted.toString(), "/deleteTopics/"))
+              complete(StatusCodes.Accepted, response)
+            }
+          }
+        }
+      }
+      case Failure(e) => {
+        topics.map(topicName => addPromHttpMetric(topicName, StatusCodes.InternalServerError.toString(), "/deleteTopics/"))
+        complete(StatusCodes.InternalServerError, e.getMessage)
+      }
+    }
+  }
+
   override val route: Route =
     handleExceptions(exceptionHandler) {
-      path("deleteTopics" / Segment) { topic =>
-        extractExecutionContext { implicit ec =>
+      extractExecutionContext { implicit ec =>
+        pathPrefix("v2" / "topics") {
           pathEndOrSingleSlash {
             delete {
-              val maybeList = topic.split(",").toList
-              // check if consumers exist for this topic, if they do fail and return consumer groups
-              // try deleting topic
-
-              onComplete(
-                Futurable[F].unsafeToFuture(deletionProgram.deleteTopic(maybeList))
-              ) {
-                case Success(maybeSuccess) => {
-                  maybeSuccess match {
-                    case Validated.Valid(a) => {
-                      maybeList.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))
-                      complete(StatusCodes.OK)
-                    }
-                    case Validated.Invalid(e) => {
-                      e.asInstanceOf[DeleteTopicError] match {
-                        case SchemaDeletionErrors(schemaDeleteTopicErrorList) => {
-                          val badTopics = schemaDeleteTopicErrorList.errors.toList.map(error => error.errorMessage.split("-").head)
-                          val goodTopics = maybeList.toSet.diff(badTopics.toSet).toList
-                          badTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.InternalServerError.toString(), "/deleteTopics/"))
-                          goodTopics.map(topicName => addPromHttpMetric(topicName, StatusCodes.OK.toString(), "/deleteTopics/"))
-                          complete(StatusCodes.Accepted, schemaDeleteTopicErrorList.errors.toList.map(error => error.errorMessage))
-                        }
-                      }
-                    }
-                  }
-                }
+              entity(as[DeletionRequest]) { req =>
+                val maybeList = req.valPayload
+                  .replace("[","")
+                  .replace("\"","")
+                  .replace(" ","")
+                  .replace("]","").split(",").toList
+                // check if consumers exist for this topic, if they do fail and return consumer groups
+                // try deleting topic
+                deleteTopics(maybeList)
               }
+            }
+          }
+          pathPrefix(Segment) { topic =>
+            pathEndOrSingleSlash {
+              deleteTopics(List(topic))
             }
           }
         }

--- a/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
@@ -3,6 +3,7 @@ package hydra.ingest.modules
 import cats.effect._
 import cats.implicits._
 import hydra.ingest.app.AppConfig.AppConfig
+import hydra.ingest.programs.TopicDeletionProgram
 import hydra.ingest.services.{IngestionFlow, IngestionFlowV2}
 import hydra.kafka.programs.CreateTopicProgram
 import io.chrisdavenport.log4cats.Logger
@@ -39,6 +40,11 @@ final class Programs[F[_]: Logger: Sync: Timer: Mode] private(
     algebras.schemaRegistry,
     algebras.kafkaClient,
     cfg.createTopicConfig.schemaRegistryConfig.fullUrl
+  )
+
+  val topicDeletion: TopicDeletionProgram[F] = new TopicDeletionProgram[F](
+    algebras.kafkaAdmin,
+    algebras.schemaRegistry
   )
 
 }

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -51,6 +51,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
                             programs.ingestionFlowV2,
                             cfg.ingestConfig.useOldIngestIfUAContains).route ~
       new TopicsEndpoint(consumerProxy)(system.dispatcher).route ~
+      new TopicDeletionEndpoint(programs.topicDeletion,cfg.topicDeletionConfig.deleteTopicPassword).route ~
       HealthEndpoint.route ~
       bootstrapEndpointV2
   }

--- a/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
+++ b/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
@@ -1,0 +1,84 @@
+package hydra.ingest.programs
+
+import cats.Monad
+import cats.MonadError
+import cats.effect.Sync
+import hydra.avro.registry.SchemaRegistry
+import hydra.avro.registry.SchemaRegistry.SchemaVersion
+import hydra.common.util.Futurable
+import hydra.kafka.algebras.KafkaAdminAlgebra.{DeleteTopicError, DeleteTopicErrorList}
+import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
+import cats.data.{NonEmptyChain, NonEmptyList, Validated, ValidatedNec, ValidatedNel}
+import cats.implicits._
+import cats.effect.concurrent.Ref
+import cats.effect.{Async, Concurrent, ConcurrentEffect, ContextShift, Resource, Sync, Timer}
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+final class TopicDeletionProgram[F[_]: MonadError[*[_], Throwable]](kafkaClient: KafkaAdminAlgebra[F],
+                                              schemaClient: SchemaRegistry[F]) {
+
+  private def deleteVersionFromSchemaRegistry(schemaVersion: SchemaVersion, topic: String): F[Either[DeleteTopicError, Unit]] = {
+    schemaClient.deleteSchemaOfVersion(topic, schemaVersion).attempt.map(_.leftMap(DeleteTopicError(topic,_)))
+  }
+
+  private def getVersionFromSchemaRegistry(topic: String): F[Either[DeleteTopicError, List[SchemaVersion]]] = {
+    schemaClient.getAllVersions(topic).attempt.map(_.leftMap(DeleteTopicError(topic, _)))
+  }
+
+  private def deleteFromSchemaRegistry(topicNames: List[String]): F[Either[DeleteTopicErrorList, Unit]] = {
+    topicNames.traverse { topic =>
+      val maybeVersion = getVersionFromSchemaRegistry(topic)
+      maybeVersion.flatMap(_.traverse(versions => versions.traverse(deleteVersionFromSchemaRegistry(_,topic))))
+    }
+  }
+
+  def deleteTopic(topicNames: List[String]): F[Either[DeleteTopicErrorList, Unit]] = {
+    kafkaClient.deleteTopics(topicNames).flatMap{
+      case Right(value) =>{
+        deleteFromSchemaRegistry(topicNames) match {
+          case Left(errorList) => return Left(errorList)
+          case Right(_) => return Right(Unit)
+        }
+      }
+      case Left(value) =>
+    }
+
+
+//    {
+//      case Success(maybeSuccess) => {
+//        case Success(Right) => {
+//          // delete all from schema registry
+//
+//        }
+//        case Success(Left) => {
+//          // Either partial success or full failure
+//          maybeSuccess.left.map{ topicErrors =>
+//            val erroredTopicNames = topicErrors.errors.map(topicError => topicError.topicName).toList
+//            if (erroredTopicNames.length == topicNames.length) {
+//              // No success
+//              return Left(topicErrors)
+//            } else {
+//              // partial success
+//              val partialSuccess = topicNames.filter(topic => !erroredTopicNames.contains(topic))
+//              deleteFromSchemaRegistry(partialSuccess) match {
+//                case Left(value) => topicErrors += value
+//              }
+//              return Left(topicErrors)
+//            }
+//          }
+//        }
+//        case Failure(e) => {
+//          return Left(DeleteTopicErrorList(topicNames.map(topic => DeleteTopicError(topic, e)).toNonEmptyList))
+//        }
+//      }
+//      case Failure(e) =>  {
+//        return Left(DeleteTopicErrorList(topicNames.map(topic => DeleteTopicError(topic, e)).toNonEmptyList))
+//      }
+//    }
+  }
+}

--- a/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
+++ b/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
@@ -13,7 +13,7 @@ import hydra.ingest.programs.TopicDeletionProgram.{FailureToDeleteSchemaVersion,
 final class TopicDeletionProgram[F[_]: MonadError[*[_], Throwable]](kafkaClient: KafkaAdminAlgebra[F],
                                               schemaClient: SchemaRegistry[F]) {
 
-  private def deleteFromSchemaRegistry(topicNames: List[String]): F[ValidatedNel[SchemaRegistryError, Unit]] = {
+  def deleteFromSchemaRegistry(topicNames: List[String]): F[ValidatedNel[SchemaRegistryError, Unit]] = {
     topicNames.flatMap(topic => List(topic + "-key", topic + "-value")).traverse { subject =>
       schemaClient.getAllVersions(subject).attempt.flatMap {
         case Right(versions) =>

--- a/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
+++ b/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
@@ -49,15 +49,16 @@ final class TopicDeletionProgram[F[_]: MonadError[*[_], Throwable]](kafkaClient:
 
 object TopicDeletionProgram {
 
-  sealed abstract class SchemaRegistryError(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+  sealed abstract class SchemaRegistryError(subject: String, message: String, cause: Throwable) extends RuntimeException(message, cause) {
     def errorMessage: String = s"$message $cause"
+    def getSubject: String = subject
   }
 
   final case class FailureToGetSchemaVersions(subject: String, cause: Throwable)
-    extends SchemaRegistryError(s"Unable to get all schema versions for $subject", cause)
+    extends SchemaRegistryError(subject, s"Unable to get all schema versions for $subject", cause)
 
   final case class FailureToDeleteSchemaVersion(schemaVersion: SchemaVersion, subject: String, cause: Throwable)
-    extends SchemaRegistryError(s"Failed to delete $schemaVersion for $subject", cause)
+    extends SchemaRegistryError(subject, s"Failed to delete version: $schemaVersion for $subject", cause)
 
   final case class SchemaDeleteTopicErrorList(errors: NonEmptyList[SchemaRegistryError])
     extends Exception (s"Topic(s) failed to delete:\n${errors.map(_.errorMessage).toList.mkString("\n")}")

--- a/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
+++ b/ingest/src/main/scala/hydra.ingest/programs/TopicDeletionProgram.scala
@@ -14,7 +14,6 @@ final class TopicDeletionProgram[F[_]: MonadError[*[_], Throwable]](kafkaClient:
                                               schemaClient: SchemaRegistry[F]) {
 
   private def deleteFromSchemaRegistry(topicNames: List[String]): F[ValidatedNel[SchemaRegistryError, Unit]] = {
-    // Try deleting both -key and -value
     topicNames.flatMap(topic => List(topic + "-key", topic + "-value")).traverse { subject =>
       // Delete all versions of the schema
       schemaClient.getAllVersions(subject).attempt.flatMap {

--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -83,8 +83,6 @@ class TopicDeletionEndpointSpec extends Matchers with AnyWordSpecLike with Scala
       // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
       override def getConsumerLag(topic: TopicName, consumerGroup: String): F[Map[TopicAndPartition, LagOffsets]] = ???
 
-      override def kafkaContainsTopic(name: TopicName): F[Boolean] = getTopicNames.map(topics => false)
-
       override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
         Sync[F].pure(Left(new KafkaDeleteTopicErrorList(NonEmptyList.fromList(
           topicNames.map(topic => KafkaDeleteTopicError(topic, new Exception("Unable to delete topic")))).get)))

--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -54,7 +54,6 @@ class TopicDeletionEndpointSpec extends Matchers with AnyWordSpecLike with Scala
 
       override def getSchemaRegistryClient: F[SchemaRegistryClient] = underlying.getSchemaRegistryClient
 
-      //TODO: Test this
       override def getLatestSchemaBySubject(subject: String): F[Option[Schema]] = underlying.getLatestSchemaBySubject(subject)
 
       override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): F[Option[Schema]] = underlying.getSchemaFor(subject, schemaVersion)

--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -1,6 +1,5 @@
 package hydra.ingest.http
 
-import akka.actor.ActorSystem
 import cats.data.NonEmptyList
 import cats.effect.{IO, Sync}
 import hydra.avro.registry.SchemaRegistry
@@ -10,18 +9,14 @@ import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.matchers.should.Matchers
 import cats.implicits._
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
-import akka.http.scaladsl.client.RequestBuilding._
 import hydra.ingest.programs.TopicDeletionProgram
 import hydra.kafka.algebras.KafkaAdminAlgebra.{KafkaDeleteTopicError, KafkaDeleteTopicErrorList, LagOffsets, Offset, Topic, TopicAndPartition, TopicName}
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
-import akka.actor.{Actor, ActorRef, ActorSelection, ActorSystem, Props}
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCode, StatusCodes}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit._
-import akka.testkit.TestKit._
-import hydra.common.config.ConfigSupport
 
 
 

--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -1,0 +1,238 @@
+package hydra.ingest.http
+
+import akka.actor.ActorSystem
+import cats.data.NonEmptyList
+import cats.effect.{IO, Sync}
+import hydra.avro.registry.SchemaRegistry
+import hydra.kafka.algebras.KafkaAdminAlgebra
+import hydra.kafka.util.KafkaUtils.TopicDetails
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.scalatest.matchers.should.Matchers
+import cats.implicits._
+import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
+import akka.http.scaladsl.client.RequestBuilding._
+import hydra.ingest.programs.TopicDeletionProgram
+import hydra.kafka.algebras.KafkaAdminAlgebra.{KafkaDeleteTopicError, KafkaDeleteTopicErrorList, LagOffsets, Offset, Topic, TopicAndPartition, TopicName}
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
+import akka.actor.{Actor, ActorRef, ActorSelection, ActorSystem, Props}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCode, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit._
+import akka.testkit.TestKit._
+import hydra.common.config.ConfigSupport
+
+
+
+class TopicDeletionEndpointSpec extends Matchers with AnyWordSpecLike with ScalatestRouteTest{
+
+  import concurrent.ExecutionContext.Implicits.global
+
+  def schemaBadTest[F[_] : Sync](allowAllVersions: Boolean = true, errorOnUpgrade: Boolean = false): F[SchemaRegistry[F]] =
+    SchemaRegistry.test[F].map(sr => getFromBadSchemaRegistryClient[F](sr, allowAllVersions, errorOnUpgrade))
+
+  private def getFromBadSchemaRegistryClient[F[_] : Sync](underlying: SchemaRegistry[F], allowAllVersions: Boolean, errorOnUpgrade: Boolean): SchemaRegistry[F] =
+    new SchemaRegistry[F] {
+
+      override def registerSchema(subject: String, schema: Schema): F[SchemaId] = {
+        underlying.registerSchema(subject, schema)
+      }
+
+      override def deleteSchemaOfVersion(subject: String, version: SchemaVersion): F[Unit] =
+        if (errorOnUpgrade && version > 1) {
+          Sync[F].raiseError(new Exception(s"Error on version $version"))
+        } else {
+          underlying.deleteSchemaOfVersion(subject, version)
+        }
+
+      override def getVersion(subject: String, schema: Schema): F[SchemaVersion] =
+        underlying.getVersion(subject, schema)
+
+      override def getAllVersions(subject: String): F[List[SchemaId]] =
+        if (allowAllVersions) underlying.getAllVersions(subject)
+        else if(!allowAllVersions && subject.contains("-key")) underlying.getAllVersions(subject)
+        else Sync[F].raiseError(new Exception("Unable to get all versions"))
+
+      override def getAllSubjects: F[List[String]] =
+        underlying.getAllSubjects
+
+      override def getSchemaRegistryClient: F[SchemaRegistryClient] = underlying.getSchemaRegistryClient
+
+      //TODO: Test this
+      override def getLatestSchemaBySubject(subject: String): F[Option[Schema]] = underlying.getLatestSchemaBySubject(subject)
+
+      override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): F[Option[Schema]] = underlying.getSchemaFor(subject, schemaVersion)
+
+    }
+
+  def kafkaBadTest[F[_] : Sync]: F[KafkaAdminAlgebra[F]] =
+    KafkaAdminAlgebra.test[F].flatMap(getBadTestKafkaClient[F])
+
+  private[this] def getBadTestKafkaClient[F[_] : Sync](underlying: KafkaAdminAlgebra[F]): F[KafkaAdminAlgebra[F]] = Sync[F].delay {
+    new KafkaAdminAlgebra[F] {
+      override def describeTopic(name: TopicName): F[Option[Topic]] = underlying.describeTopic(name)
+
+      override def getTopicNames: F[List[TopicName]] =
+        underlying.getTopicNames
+
+      override def createTopic(name: TopicName, details: TopicDetails): F[Unit] = underlying.createTopic(name, details)
+
+      override def deleteTopic(name: String): F[Unit] = ???
+
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getConsumerGroupOffsets(consumerGroup: String): F[Map[TopicAndPartition, Offset]] = ???
+
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getLatestOffsets(topic: TopicName): F[Map[TopicAndPartition, Offset]] = ???
+
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getConsumerLag(topic: TopicName, consumerGroup: String): F[Map[TopicAndPartition, LagOffsets]] = ???
+
+      override def kafkaContainsTopic(name: TopicName): F[Boolean] = getTopicNames.map(topics => false)
+
+      override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
+        Sync[F].pure(Left(new KafkaDeleteTopicErrorList(NonEmptyList.fromList(
+          topicNames.map(topic => KafkaDeleteTopicError(topic, new Exception("Unable to delete topic")))).get)))
+    }
+  }
+
+  private def buildSchema(topic: String, upgrade: Boolean): Schema = {
+    val schemaStart = SchemaBuilder.record("name" + topic.replace("-", "").replace(".", ""))
+      .fields().requiredString("id" + topic.replace("-", "").replace(".", ""))
+    if (upgrade && !topic.contains("-key")) {
+      schemaStart.nullableBoolean("upgrade", upgrade).endRecord()
+    } else {
+      schemaStart.endRecord()
+    }
+  }
+
+  private def registerTopics(topicNames: List[String], schemaAlgebra: SchemaRegistry[IO],
+                             registerKey: Boolean, upgrade: Boolean): IO[List[SchemaId]] = {
+    topicNames.flatMap(topic => if (registerKey) List(topic + "-key", topic + "-value") else List(topic + "-value"))
+      .traverse(topic => schemaAlgebra.registerSchema(topic, buildSchema(topic, upgrade)))
+  }
+
+
+  "The deletionEndpoint path" should {
+    "return 200 with single deletion in body" in {
+      val topic = List("exp.blah.blah")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- SchemaRegistry.test[IO]
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+        allTopics <- kafkaAlgebra.getTopicNames
+      } yield {
+        allTopics shouldBe topic
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe """["exp.blah.blah"]"""
+          status shouldBe StatusCodes.OK
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 200 with multiple deletions" in {
+      val topic = List("exp.blah.blah","exp.hello.world","exp.hi.there")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- SchemaRegistry.test[IO]
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+      } yield {
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah,exp.hello.world,exp.hi.there"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe "[\"exp.blah.blah\",\"exp.hello.world\",\"exp.hi.there\"]"
+          status shouldBe StatusCodes.OK
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 500 if one topic not successful from Kafka" in {
+      val topic = List("exp.blah.blah")
+      (for {
+        kafkaAlgebra <- kafkaBadTest[IO]
+        schemaAlgebra <- SchemaRegistry.test[IO]
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+      } yield {
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe "[{\"message\":\"exp.blah.blah Unable to delete topic\",\"topicOrSubject\":\"exp.blah.blah\"}]"
+          status shouldBe StatusCodes.InternalServerError
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 500 if unable to get all schema versions for -value" in {
+      val topic = List("exp.blah.blah")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- schemaBadTest[IO](allowAllVersions = false)
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+      } yield {
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe
+            """[{"message":"Unable to get all schema versions for exp.blah.blah-value java.lang.Exception: Unable to get all versions","topicOrSubject":"exp.blah.blah-value"}]""".stripMargin
+          status shouldBe StatusCodes.InternalServerError
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 202 if unable to delete specific version" in {
+      val topic = List("exp.blah.blah")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- schemaBadTest[IO](errorOnUpgrade = true)
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+        _ <- registerTopics(topic, schemaAlgebra, registerKey= false, upgrade = true)
+      } yield {
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe """[{"message":"Failed to delete version: 2 for exp.blah.blah-value java.lang.Exception: Error on version 2","topicOrSubject":"exp.blah.blah-value"}]"""
+          status shouldBe StatusCodes.InternalServerError
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 202 if unable to delete specific version -value, but all others pass" in {
+      val topics = List("exp.blah.blah","exp.blah.ha","exp.test.this","exp.hi.There")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- schemaBadTest[IO](errorOnUpgrade = true)
+        _ <- topics.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topics, schemaAlgebra, registerKey = false, upgrade = false)
+        _ <- registerTopics(List("exp.blah.ha"), schemaAlgebra, registerKey= false, upgrade = true)
+      } yield {
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics", HttpEntity(ContentTypes.`application/json`, """{"topics":["exp.blah.blah, exp.blah.ha, exp.test.this, exp.hi.There"]}""")) ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe """[{"message":"Failed to delete version: 2 for exp.blah.ha-value java.lang.Exception: Error on version 2","topicOrSubject":"exp.blah.ha-value"}]"""
+          status shouldBe StatusCodes.Accepted
+        }
+      }).unsafeRunSync()
+    }
+
+    "return 200 with single deletion in url" in {
+      val topic = List("exp.blah.blah")
+      (for {
+        kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+        schemaAlgebra <- SchemaRegistry.test[IO]
+        _ <- topic.traverse(t => kafkaAlgebra.createTopic(t,TopicDetails(1,1)))
+        _ <- registerTopics(topic, schemaAlgebra, registerKey = false, upgrade = false)
+        allTopics <- kafkaAlgebra.getTopicNames
+      } yield {
+        allTopics shouldBe topic
+        val route = new TopicDeletionEndpoint[IO](new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra)).route
+        Delete("/v2/topics/exp.blah.blah") ~> Route.seal(route) ~> check {
+          responseAs[String] shouldBe """["exp.blah.blah"]"""
+          status shouldBe StatusCodes.OK
+        }
+      }).unsafeRunSync()
+    }
+
+  }
+
+}

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -1,0 +1,5 @@
+package hydra.ingest.programs
+
+class TopicDeletionProgramSpec {
+
+}

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -150,20 +150,6 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
       List.empty, upgradeTopic, assertionError)
   }
 
-  private def applyFailureTestcase(kafkaAdminAlgebra: IO[KafkaAdminAlgebra[IO]],
-                                   schemaRegistry: IO[SchemaRegistry[IO]],
-                                   topicNames: List[String],
-                                   topicNamesToDelete: List[String],
-                                   registerKey: Boolean,
-                                   kafkaTopicNamesToFail: List[String] = List.empty,
-                                   schemasToSucceed: List[String] = List.empty,
-                                   assertionError: ErrorChecker = _ => (),
-                                   upgradeTopic: Tuple2[String, Boolean] = ("", false)): Unit = {
-    applyTestcase(kafkaAdminAlgebra, schemaRegistry,
-      topicNames, topicNamesToDelete, schemasToSucceed, registerKey,
-      kafkaTopicNamesToFail, upgradeTopic, assertionError)
-  }
-
 
   it should "Delete a Single Topic from Kafka value only" in {
     applyGoodTestcase(List("topic1"), List("topic1"))
@@ -199,24 +185,24 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
 
   // FAILURE CASES
   it should "Return a KafkaDeletionError if the topic fails to delete" in {
-    applyFailureTestcase(kafkabadTest[IO], SchemaRegistry.test[IO],
+    applyTestcase(kafkabadTest[IO], SchemaRegistry.test[IO],
       topicNames = twoTopics, topicNamesToDelete = twoTopics,
       registerKey = true, kafkaTopicNamesToFail = twoTopics,
-      schemasToSucceed = twoTopics, invalidErrorChecker)
+      schemasToSucceed = twoTopics, assertionError = invalidErrorChecker)
   }
 
   it should "Return a SchemaDeletionError if getting all versions fail" in {
-    applyFailureTestcase(KafkaAdminAlgebra.test[IO], schemaBadTest[IO](allowAllVersions = false),
+    applyTestcase(KafkaAdminAlgebra.test[IO], schemaBadTest[IO](allowAllVersions = false),
       topicNames = twoTopics, topicNamesToDelete = List("topic1"),
       registerKey = true, kafkaTopicNamesToFail = List.empty,
-      schemasToSucceed = List("topic2"), invalidErrorChecker)
+      schemasToSucceed = List("topic2"), assertionError = invalidErrorChecker)
   }
 
   it should "Return a SchemaDeletionError if deleting a specific version fails" in {
-    applyFailureTestcase(KafkaAdminAlgebra.test[IO], schemaBadTest[IO](errorOnUpgrade = true),
+    applyTestcase(KafkaAdminAlgebra.test[IO], schemaBadTest[IO](errorOnUpgrade = true),
       topicNames = twoTopics, topicNamesToDelete = List("topic1"),
       registerKey = true, kafkaTopicNamesToFail = List.empty,
-      schemasToSucceed = List("topic2"), invalidErrorChecker, upgradeTopic = ("topic1" ,true))
+      schemasToSucceed = List("topic2"), assertionError = invalidErrorChecker, upgradeTopic = ("topic1" ,true))
   }
 
 }

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -7,108 +7,50 @@ import hydra.kafka.util.KafkaUtils.TopicDetails
 import org.apache.avro.SchemaBuilder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import cats.implicits._
 
 class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
-  it should "Delete Topics from Kafka value only" in {
+
+  private def applyTestcase(kafkaAdminAlgebra: IO[KafkaAdminAlgebra[IO]],
+                           schemaRegistry: IO[SchemaRegistry[IO]],
+                            topicNames: List[String],
+                            topicNamesToDelete: List[String],
+                            registerKey: Boolean): Unit = {
     (for {
-      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
-      schemaAlgebra <- SchemaRegistry.test[IO]
-      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
-      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
-      finalTopic <- kafkaAlgebra.describeTopic("test1")
-      finalSchema <- schemaAlgebra.getSchemaFor("test1-value",1)
+      kafkaAlgebra <- kafkaAdminAlgebra
+      schemaAlgebra <- schemaRegistry
+      _ <- topicNames.traverse(topic => kafkaAlgebra.createTopic(topic,TopicDetails(1,1)))
+      _ <- topicNames.flatMap(topic => if(registerKey) List(topic + "-key", topic + "-value") else List(topic + "-value")).traverse(topic =>
+        schemaAlgebra.registerSchema(topic,
+          SchemaBuilder.record("name" + topic.replace("-",""))
+            .fields().requiredString("id" + topic.replace("-","")).endRecord()))
+      _ <-  new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(topicNamesToDelete)
+      allTopics <- kafkaAlgebra.getTopicNames
+      allSchemas <- topicNames.traverse(topic => schemaAlgebra.getAllVersions(topic + "-value").map(versions => if(versions.nonEmpty) Some(topic + "-value") else None)).map(_.flatten)
     } yield {
-      finalTopic shouldBe None
-      finalSchema shouldBe None
+      allTopics shouldBe topicNames.toSet.diff(topicNamesToDelete.toSet).toList
+      allSchemas shouldBe allTopics.map(topic => topic + "-value")
     }).unsafeRunSync()
   }
 
-  it should "Delete Topics from Kafka key and value" in {
-    (for {
-      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
-      schemaAlgebra <- SchemaRegistry.test[IO]
-      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
-      _ <- schemaAlgebra.registerSchema("test1-key", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
-      finalTopic <- kafkaAlgebra.describeTopic("test1")
-      finalValueSchema <- schemaAlgebra.getSchemaFor("test1-value",1)
-      finalKeySchema <- schemaAlgebra.getSchemaFor("test1-key",1)
-    } yield {
-      finalTopic shouldBe None
-      finalKeySchema shouldBe None
-      finalValueSchema shouldBe None
-    }).unsafeRunSync()
+  it should "Delete Single Topic from Kafka value only" in {
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1"), List("topic1"), registerKey = false)
+  }
+
+  it should "Delete Single Topic from Multiple topics in Kafka value only" in {
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1","topic2"), List("topic1"), registerKey = false)
+  }
+
+  it should "Delete Single Topic from Multiple topics in Kafka key and value" in {
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1","topic2"), List("topic1"), registerKey = true)
   }
 
   it should "Delete Multiple Topics from Kafka value only" in {
-    (for {
-      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
-      schemaAlgebra <- SchemaRegistry.test[IO]
-      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
-      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
-      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
-      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1", "test2"))
-      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
-      finalTopicTwo <- kafkaAlgebra.describeTopic("test2")
-      finalSchemaOne <- schemaAlgebra.getSchemaFor("test1-value",1)
-      finalSchemaTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
-    } yield {
-      finalTopicOne shouldBe None
-      finalSchemaOne shouldBe None
-      finalTopicTwo shouldBe None
-      finalSchemaTwo shouldBe None
-    }).unsafeRunSync()
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic1","topic2"), registerKey = false)
   }
 
   it should "Delete Multiple Topics from Kafka key and value" in {
-    (for {
-      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
-      schemaAlgebra <- SchemaRegistry.test[IO]
-      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
-      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
-      _ <- schemaAlgebra.registerSchema("test1-key", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- schemaAlgebra.registerSchema("test2-key", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
-      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
-      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1", "test2"))
-      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
-      finalTopicTwo <- kafkaAlgebra.describeTopic("test2")
-      finalSchemaKeyOne <- schemaAlgebra.getSchemaFor("test1-key",1)
-      finalSchemaKeyTwo <- schemaAlgebra.getSchemaFor("test2-key",1)
-      finalSchemaValueOne <- schemaAlgebra.getSchemaFor("test1-value",1)
-      finalSchemaValueTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
-    } yield {
-      finalTopicOne shouldBe None
-      finalSchemaKeyOne shouldBe None
-      finalSchemaValueOne shouldBe None
-      finalTopicTwo shouldBe None
-      finalSchemaKeyTwo shouldBe None
-      finalSchemaValueTwo shouldBe None
-    }).unsafeRunSync()
-  }
-
-  it should "Delete Only Topic listed from Kafka value only" in {
-    (for {
-      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
-      schemaAlgebra <- SchemaRegistry.test[IO]
-      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
-      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
-      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
-      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
-      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
-      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
-      finalTopicTwo <- kafkaAlgebra.kafkaContainsTopic("test2")
-      finalSchemaOne <- schemaAlgebra.getSchemaFor("test1-value",1)
-      finalSchemaTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
-    } yield {
-      finalTopicOne shouldBe None
-      finalSchemaOne shouldBe None
-      finalTopicTwo shouldBe true
-      finalSchemaTwo shouldBe Some(SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
-    }).unsafeRunSync()
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic1","topic2"), registerKey = true)
   }
 
 }

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -1,5 +1,114 @@
 package hydra.ingest.programs
 
-class TopicDeletionProgramSpec {
+import cats.effect.IO
+import hydra.avro.registry.SchemaRegistry
+import hydra.kafka.algebras.KafkaAdminAlgebra
+import hydra.kafka.util.KafkaUtils.TopicDetails
+import org.apache.avro.SchemaBuilder
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
+  it should "Delete Topics from Kafka value only" in {
+    (for {
+      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+      schemaAlgebra <- SchemaRegistry.test[IO]
+      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
+      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
+      finalTopic <- kafkaAlgebra.describeTopic("test1")
+      finalSchema <- schemaAlgebra.getSchemaFor("test1-value",1)
+    } yield {
+      finalTopic shouldBe None
+      finalSchema shouldBe None
+    }).unsafeRunSync()
+  }
+
+  it should "Delete Topics from Kafka key and value" in {
+    (for {
+      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+      schemaAlgebra <- SchemaRegistry.test[IO]
+      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
+      _ <- schemaAlgebra.registerSchema("test1-key", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
+      finalTopic <- kafkaAlgebra.describeTopic("test1")
+      finalValueSchema <- schemaAlgebra.getSchemaFor("test1-value",1)
+      finalKeySchema <- schemaAlgebra.getSchemaFor("test1-key",1)
+    } yield {
+      finalTopic shouldBe None
+      finalKeySchema shouldBe None
+      finalValueSchema shouldBe None
+    }).unsafeRunSync()
+  }
+
+  it should "Delete Multiple Topics from Kafka value only" in {
+    (for {
+      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+      schemaAlgebra <- SchemaRegistry.test[IO]
+      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
+      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
+      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
+      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1", "test2"))
+      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
+      finalTopicTwo <- kafkaAlgebra.describeTopic("test2")
+      finalSchemaOne <- schemaAlgebra.getSchemaFor("test1-value",1)
+      finalSchemaTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
+    } yield {
+      finalTopicOne shouldBe None
+      finalSchemaOne shouldBe None
+      finalTopicTwo shouldBe None
+      finalSchemaTwo shouldBe None
+    }).unsafeRunSync()
+  }
+
+  it should "Delete Multiple Topics from Kafka key and value" in {
+    (for {
+      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+      schemaAlgebra <- SchemaRegistry.test[IO]
+      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
+      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
+      _ <- schemaAlgebra.registerSchema("test1-key", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- schemaAlgebra.registerSchema("test2-key", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
+      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
+      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1", "test2"))
+      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
+      finalTopicTwo <- kafkaAlgebra.describeTopic("test2")
+      finalSchemaKeyOne <- schemaAlgebra.getSchemaFor("test1-key",1)
+      finalSchemaKeyTwo <- schemaAlgebra.getSchemaFor("test2-key",1)
+      finalSchemaValueOne <- schemaAlgebra.getSchemaFor("test1-value",1)
+      finalSchemaValueTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
+    } yield {
+      finalTopicOne shouldBe None
+      finalSchemaKeyOne shouldBe None
+      finalSchemaValueOne shouldBe None
+      finalTopicTwo shouldBe None
+      finalSchemaKeyTwo shouldBe None
+      finalSchemaValueTwo shouldBe None
+    }).unsafeRunSync()
+  }
+
+  it should "Delete Only Topic listed from Kafka value only" in {
+    (for {
+      kafkaAlgebra <- KafkaAdminAlgebra.test[IO]
+      schemaAlgebra <- SchemaRegistry.test[IO]
+      _ <- kafkaAlgebra.createTopic("test1", TopicDetails(1,1))
+      _ <- kafkaAlgebra.createTopic("test2", TopicDetails(1,1))
+      _ <- schemaAlgebra.registerSchema("test1-value", SchemaBuilder.record("name").fields().requiredString("id").endRecord())
+      _ <- schemaAlgebra.registerSchema("test2-value", SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
+      _ <- new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(List("test1"))
+      finalTopicOne <- kafkaAlgebra.describeTopic("test1")
+      finalTopicTwo <- kafkaAlgebra.kafkaContainsTopic("test2")
+      finalSchemaOne <- schemaAlgebra.getSchemaFor("test1-value",1)
+      finalSchemaTwo <- schemaAlgebra.getSchemaFor("test2-value",1)
+    } yield {
+      finalTopicOne shouldBe None
+      finalSchemaOne shouldBe None
+      finalTopicTwo shouldBe true
+      finalSchemaTwo shouldBe Some(SchemaBuilder.record("name2").fields().requiredString("id2").endRecord())
+    }).unsafeRunSync()
+  }
 
 }

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -2,16 +2,97 @@ package hydra.ingest.programs
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
-import cats.effect.IO
-import hydra.avro.registry.SchemaRegistry
+import cats.effect.concurrent.Ref
+import cats.effect.{IO, Sync}
+import hydra.avro.registry.{SchemaRegistry, SchemaRegistryException}
 import hydra.kafka.algebras.KafkaAdminAlgebra
 import hydra.kafka.util.KafkaUtils.TopicDetails
-import org.apache.avro.SchemaBuilder
+import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import cats.implicits._
+import hydra.avro.registry.SchemaRegistry.{IncompatibleSchemaException, SchemaId, SchemaVersion}
+import hydra.kafka.algebras.KafkaAdminAlgebra.{KafkaDeleteTopicError, KafkaDeleteTopicErrorList, LagOffsets, Offset, Topic, TopicAndPartition, TopicName}
+import io.confluent.kafka.schemaregistry.client.{MockSchemaRegistryClient, SchemaRegistryClient}
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 
 class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
+
+  def schemaBadTest[F[_]: Sync]: F[SchemaRegistry[F]] = Sync[F].delay {
+    getFromBadSchemaRegistryClient(new MockSchemaRegistryClient)
+  }
+
+  private def getFromBadSchemaRegistryClient[F[_]: Sync](schemaRegistryClient: SchemaRegistryClient): SchemaRegistry[F] =
+    new SchemaRegistry[F] {
+
+      private implicit class CheckKeySchemaEvolution(schemasF: F[List[Schema]]) {
+        Sync[F].raiseError(IncompatibleSchemaException(s"Key schema evolutions are not permitted."))
+      }
+
+      override def registerSchema(subject: String,schema: Schema): F[SchemaId] = {
+        Sync[F].delay(0)
+      }
+
+      override def deleteSchemaOfVersion(subject: String,version: SchemaVersion): F[Unit] =
+        Sync[F].raiseError(new SchemaRegistryException(new Exception(s"Unable to delete $version of $subject"), subject))
+
+      override def getVersion(subject: String,schema: Schema): F[SchemaVersion] =
+        Sync[F].raiseError(new Exception(s"Unable to get version for $subject"))
+
+      override def getAllVersions(subject: String): F[List[SchemaId]] =
+        Sync[F].raiseError(new SchemaRegistryException(new Exception(s"Unable to get all versions of $subject"), subject))
+
+      override def getAllSubjects: F[List[String]] =
+        Sync[F].raiseError(new Exception("Unable to get all Subjects"))
+
+      override def getSchemaRegistryClient: F[SchemaRegistryClient] = Sync[F].pure(schemaRegistryClient)
+
+      //TODO: Test this
+      override def getLatestSchemaBySubject(subject: String): F[Option[Schema]] = Sync[F].raiseError(new Exception("LatestSchemaBySubject failed"))
+
+      override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): F[Option[Schema]] =
+        Sync[F].raiseError(new Exception(s"getSchemaFor failed for version $schemaVersion of $subject"))
+
+    }
+
+  def kafkabadTest[F[_]: Sync]: F[KafkaAdminAlgebra[F]] =
+    Ref[F].of(Map[TopicName, Topic]()).flatMap(getBadTestKafkaClient[F])
+
+  private[this] def getBadTestKafkaClient[F[_]: Sync](ref: Ref[F, Map[TopicName, Topic]]): F[KafkaAdminAlgebra[F]] = Sync[F].delay  {
+    new KafkaAdminAlgebra[F] {
+      override def describeTopic(name: TopicName): F[Option[Topic]] =
+      // return None
+        ref.get.map(_ => None)
+
+      override def getTopicNames: F[List[TopicName]] =
+      // return empty list
+        ref.get.map(_ => List())
+
+      override def createTopic(
+                                name: TopicName,
+                                details: TopicDetails
+                              ): F[Unit] = {
+        ref.update(old => old)
+      }
+
+      override def deleteTopic(name: String): F[Unit] =
+        Sync[F].raiseError(new Exception("An exception has occured in your deleteTopic"))
+
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getConsumerGroupOffsets(consumerGroup: String): F[Map[TopicAndPartition, Offset]] = ???
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getLatestOffsets(topic: TopicName): F[Map[TopicAndPartition, Offset]] = ???
+      // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
+      override def getConsumerLag(topic: TopicName, consumerGroup: String): F[Map[TopicAndPartition, LagOffsets]] = ???
+
+      override def kafkaContainsTopic(name: TopicName): F[Boolean] =
+        getTopicNames.map(topics => false)
+
+      override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
+        Sync[F].pure(Left(new KafkaDeleteTopicErrorList( NonEmptyList.fromList(
+          topicNames.map(topic => KafkaDeleteTopicError(topic, new Exception("Unable to delete topic")))).get)))
+    }
+  }
 
   private type ErrorChecker = ValidatedNel[DeleteTopicError, Unit] => Unit
 
@@ -20,15 +101,19 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
                             topicNames: List[String],
                             topicNamesToDelete: List[String],
                             registerKey: Boolean,
+                            topicNamesToFail: List[String] = List.empty,
                             assertionError: ErrorChecker = _ => ()): Unit = {
     (for {
       kafkaAlgebra <- kafkaAdminAlgebra
       schemaAlgebra <- schemaRegistry
+      // create all topics
       _ <- topicNames.traverse(topic => kafkaAlgebra.createTopic(topic,TopicDetails(1,1)))
+      // register all topics
       _ <- topicNames.flatMap(topic => if(registerKey) List(topic + "-key", topic + "-value") else List(topic + "-value")).traverse(topic =>
         schemaAlgebra.registerSchema(topic,
           SchemaBuilder.record("name" + topic.replace("-",""))
             .fields().requiredString("id" + topic.replace("-","")).endRecord()))
+      // delete all given topics to delete
       errors <-  new TopicDeletionProgram[IO](kafkaAlgebra, schemaAlgebra).deleteTopic(topicNamesToDelete)
       allTopics <- kafkaAlgebra.getTopicNames
       allSchemas <- topicNames.traverse(topic => schemaAlgebra.getAllVersions(topic + "-value").map(versions => if(versions.nonEmpty) Some(topic + "-value") else None)).map(_.flatten)
@@ -39,29 +124,47 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
     }).unsafeRunSync()
   }
 
-  it should "Delete Single Topic from Kafka value only" in {
+  it should "Delete a Single Topic from Kafka value only" in {
     applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1"), List("topic1"), registerKey = false)
   }
 
-  it should "Delete Single Topic from Multiple topics in Kafka value only" in {
+  it should "Delete a Single Topic from Multiple topics in Kafka value only" in {
     applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1","topic2"), List("topic1"), registerKey = false)
-  }
-
-  it should "Delete Single Topic from Multiple topics in Kafka key and value" in {
-    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1","topic2"), List("topic1"), registerKey = true)
   }
 
   it should "Delete Multiple Topics from Kafka value only" in {
     applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic1","topic2"), registerKey = false)
   }
 
+  it should "Delete a Single Topic from Multiple topics in Kafka key and value" in {
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1","topic2"), List("topic1"), registerKey = true)
+  }
+
   it should "Delete Multiple Topics from Kafka key and value" in {
     applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic1","topic2"), registerKey = true)
   }
 
-  it should "Not delete topic if not exist" in {
-    val checkErrors: ErrorChecker = errors => errors shouldBe a [Invalid[KafkaDeletionErrors]]
-    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic3"), registerKey = true, checkErrors)
+  it should "Return a KafkaDeletionError if the topic does not exist" in {
+    val checkErrors: ErrorChecker = errors => errors shouldBe a [Invalid[_]]
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic3"), registerKey = true, List.empty, checkErrors)
+  }
+
+  it should "Delete nothing from Kafka or SchemaRegistry with an empty list" in {
+    applyTestcase(KafkaAdminAlgebra.test[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List(), registerKey = true)
+  }
+
+  it should "Return a SchemaDeletionError if getting all versions fail" in {
+    val checkErrors: ErrorChecker = errors => errors shouldBe a [Invalid[_]]
+    applyTestcase(kafkabadTest[IO], schemaBadTest[IO], List("topic1", "topic2"), List("topic1"), registerKey = true, List.empty, checkErrors)
+  }
+
+  it should "Return a SchemaDeletionError if deleting a specific version fails" in {
+
+  }
+
+  it should "Return a KafkaDeletionError if the topic fails to delete" in {
+    val checkErrors: ErrorChecker = errors => errors shouldBe a [Invalid[_]]
+    applyTestcase(kafkabadTest[IO], SchemaRegistry.test[IO], List("topic1", "topic2"), List("topic1", "topic2"), registerKey = true, List("topic1", "topic2"), checkErrors)
   }
 
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
@@ -223,8 +223,8 @@ object KafkaAdminAlgebra {
       override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
         topicNames.traverse{topicName =>
           deleteTopic(topicName).attempt
-            .map{ blah =>
-              blah.leftMap(
+            .map{ deleteAttempt =>
+              deleteAttempt.leftMap(
                 KafkaDeleteTopicError(topicName, _)
               ).toValidatedNel
             }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
@@ -31,13 +31,6 @@ trait KafkaAdminAlgebra[F[_]] {
   def describeTopic(name: TopicName): F[Option[Topic]]
 
   /**
-    * Checks if topic exists in Kafka
-    * @param name - name of the topic in Kafka
-    * @return True if found in Kafka, False if not found
-    */
-  def kafkaContainsTopic(name: TopicName): F[Boolean]
-
-  /**
     * Retrieves a list of all TopicName(s) found in Kafka
     * @return List[TopicName]
     */
@@ -128,13 +121,6 @@ object KafkaAdminAlgebra {
           .recover {
             case _: UnknownTopicOrPartitionException => None
           }
-      }
-
-      override def kafkaContainsTopic(name: TopicName): F[Boolean] = {
-        if(name.startsWith("_"))
-          getAdminClientResource.use(_.listTopics.includeInternal.names.map(_.toList)).map(topics => topics.contains(name))
-        else
-          getTopicNames.map(topics => topics.contains(name))
       }
 
       override def getTopicNames: F[List[TopicName]] =
@@ -233,9 +219,6 @@ object KafkaAdminAlgebra {
       override def getLatestOffsets(topic: TopicName): F[Map[TopicAndPartition, Offset]] = ???
       // This is intentionally unimplemented. This test class has no way of obtaining this offset information.
       override def getConsumerLag(topic: TopicName, consumerGroup: String): F[Map[TopicAndPartition, LagOffsets]] = ???
-
-      override def kafkaContainsTopic(name: TopicName): F[Boolean] =
-        getTopicNames.map(topics => topics.contains(name))
 
       override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
         topicNames.traverse{topicName =>

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
@@ -99,6 +99,13 @@ final class KafkaAdminAlgebraSpec
         } yield maybeTopic shouldBe(false)).unsafeRunSync()
       }
 
+      "delete multiple topics" in {
+        val topicsToDelete = List("topic1","topic2","topic3","topic4","topic5")
+        topicsToDelete.map(topic => kafkaClient.createTopic(topic, TopicDetails(1, 1)).unsafeRunSync())
+        kafkaClient.deleteTopics(topicsToDelete).map(_.unsafeRunSync())
+        topicsToDelete.map(topic => kafkaClient.kafkaContainsTopic(topic).unsafeRunSync() shouldBe false)
+      }
+
       if (!isTest) {
 
         import fs2.kafka._

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
@@ -79,9 +79,8 @@ final class KafkaAdminAlgebraSpec
         val topicCreated = "topic_created"
         (for {
           _ <- kafkaClient.createTopic(topicCreated, TopicDetails(1,1))
-          maybeExists <- kafkaClient.kafkaContainsTopic(topicCreated)
           maybeTopic <- kafkaClient.describeTopic(topicCreated)
-        } yield (maybeExists,maybeTopic) shouldBe(true,Some(Topic(topicCreated,1))) ).unsafeRunSync()
+        } yield maybeTopic shouldBe Some(Topic(topicCreated,1)) ).unsafeRunSync()
       }
 
       "delete a topic and describe" in {
@@ -93,20 +92,11 @@ final class KafkaAdminAlgebraSpec
         } yield maybeTopic should not be defined).unsafeRunSync()
       }
 
-      "delete a topic and list" in {
-        val topicToDelete = "topic_to_delete2"
-        (for {
-          _ <- kafkaClient.createTopic(topicToDelete, TopicDetails(1, 1))
-          _ <- kafkaClient.deleteTopic(topicToDelete)
-          maybeTopic <- kafkaClient.kafkaContainsTopic(topicToDelete)
-        } yield maybeTopic shouldBe(false)).unsafeRunSync()
-      }
-
       "delete multiple topics" in {
         val topicsToDelete = List("topic1","topic2","topic3","topic4","topic5")
         topicsToDelete.map(topic => kafkaClient.createTopic(topic, TopicDetails(1, 1)).unsafeRunSync())
         kafkaClient.deleteTopics(topicsToDelete).unsafeRunSync()
-        topicsToDelete.map(topic => kafkaClient.kafkaContainsTopic(topic).unsafeRunSync() shouldBe false)
+        topicsToDelete.map(topic => kafkaClient.describeTopic(topic).unsafeRunSync() shouldBe None)
       }
 
       if (!isTest) {

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/KafkaAdminAlgebraSpec.scala
@@ -102,7 +102,7 @@ final class KafkaAdminAlgebraSpec
       "delete multiple topics" in {
         val topicsToDelete = List("topic1","topic2","topic3","topic4","topic5")
         topicsToDelete.map(topic => kafkaClient.createTopic(topic, TopicDetails(1, 1)).unsafeRunSync())
-        kafkaClient.deleteTopics(topicsToDelete).map(_.unsafeRunSync())
+        kafkaClient.deleteTopics(topicsToDelete).unsafeRunSync()
         topicsToDelete.map(topic => kafkaClient.kafkaContainsTopic(topic).unsafeRunSync() shouldBe false)
       }
 

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
@@ -150,6 +150,8 @@ final class BootstrapEndpointV2Spec
         override def getLatestSchemaBySubject(subject: String): IO[Option[Schema]] = err
 
         override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): IO[Option[Schema]] = err
+
+        override def deleteSchemaSubject(subject: String): IO[Unit] = err
       }
       KafkaClientAlgebra.test[IO].flatMap { client =>
         MetadataAlgebra.make("123", "456", client, failingSchemaRegistry, true).flatMap { m =>

--- a/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
@@ -132,6 +132,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           override def getLatestSchemaBySubject(subject: String): IO[Option[Schema]] = IO.pure(None)
 
           override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): IO[Option[Schema]] = IO.pure(None)
+          override def deleteSchemaSubject(subject: String): IO[Unit] = IO.pure(())
         }
       (for {
         kafka <- KafkaAdminAlgebra.test[IO]
@@ -184,6 +185,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           override def getSchemaRegistryClient: IO[SchemaRegistryClient] = IO.raiseError(new Exception("Something horrible went wrong!"))
           override def getLatestSchemaBySubject(subject: String): IO[Option[Schema]] = IO.pure(None)
           override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): IO[Option[Schema]] = IO.pure(None)
+          override def deleteSchemaSubject(subject: String): IO[Unit] = IO.pure(())
         }
 
       (for {
@@ -241,6 +243,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           override def getSchemaRegistryClient: IO[SchemaRegistryClient] = IO.raiseError(new Exception)
           override def getLatestSchemaBySubject(subject: String): IO[Option[Schema]] = IO.pure(None)
           override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): IO[Option[Schema]] = IO.pure(None)
+          override def deleteSchemaSubject(subject: String): IO[Unit] = IO.pure(())
         }
 
       val schemaRegistryState = Map("subject-key" -> 1)


### PR DESCRIPTION
# Allows for programmatic topic deletion through Kafka and Schema Registry

## Endpoints 
1. `DELETE /v2/topics` the body must contain valid JSON `{"topics":["topicsToDeleteInStringArray"]}` 
2. `DELETE /v2/topics/{topicName}`
3. `DELETE /v2/topics/schemas/{topicName}`

Numbers 1 and 2 will attempt to delete the topic(s) from Kafka and then delete the topic(s) from Schema Registry. If all topics succeed, it will return a `200 OK` response with the topics deleted. If no topics succeed it will return a `500 Internal Server Error` with the reason that the topics failed. If some topics succeed but not all of them, it will return a `202 Accepted` in the response will be each topic that failed, and the reason that it failed. 

Number 3 will only delete the schemas for a given topic. This is helpful if the failure was due to a Schema Registry exception. You can then pass in the single topic to delete from the Schema Registry. 

## Metrics
Every topic that attempts to delete will be added to prometheus. Any that are successful will show a `200 OK`. If all topics fail, it will show a `500 Internal Server Error`. If some topics succeed and some topics fail, all that succeed will show `200 OK` all that fail will show `202 Accepted`. 

## Authentication
There must be auth in front of the deletion request. This is set through a config `HYDRA_INGEST_TOPIC_DELETION_PASSWORD`. 
If this config is not set, the default password will be an empty string allowing anyone that puts some kind of basic auth in front of the request to delete the topic. 
There is an info level log that is added that shows what user (given by the basic auth) deleted what topic. This gives allows us to have a log with a timestamp for any given deletion. 