### PR TITLE
Add recover to topicMetdata stream so it can continue. Update _hydra.v2.metadata to be compacted

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
@@ -45,7 +45,7 @@ final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
             ),
             Some("Data-Platform")
           ),
-          TopicDetails(cfg.numPartitions, cfg.replicationFactor)
+          TopicDetails(cfg.numPartitions, cfg.replicationFactor, Map("cleanup.policy" -> "compact"))
         )
       }
     } else {

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -22,7 +22,8 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
     val topicDetails =
       TopicDetails(
         cfg.createTopicConfig.defaultNumPartions,
-        cfg.createTopicConfig.defaultReplicationFactor
+        cfg.createTopicConfig.defaultReplicationFactor,
+        Map("cleanup.policy" -> "compact")
       )
     new BootstrapEndpointV2(programs.createTopic, topicDetails).route
   } else {

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -22,8 +22,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
     val topicDetails =
       TopicDetails(
         cfg.createTopicConfig.defaultNumPartions,
-        cfg.createTopicConfig.defaultReplicationFactor,
-        Map("cleanup.policy" -> "compact")
+        cfg.createTopicConfig.defaultReplicationFactor
       )
     new BootstrapEndpointV2(programs.createTopic, topicDetails).route
   } else {


### PR DESCRIPTION
getMetadata endpoint was not working in stage (and prod) because there are still topics that have underscores in the name. We no longer allow those so an exception was being thrown when the consumer came to those topics causing the consumer to stop. Adding the recover allows us to continue consuming and putting into the cache.

The topic was also meant to be compacted. It has been updated through the CLI to be compacted. Just updating in the code for consistency. 