### PR TITLE
remove where old ingest flow is being called

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
@@ -126,8 +126,6 @@ object AppConfig {
         ).parMapN(ConsumerGroupsAlgebraConfig)
 
   final case class IngestConfig(
-                                 alternateIngestEnabled: Boolean,
-                                 useOldIngestIfUAContains: Set[String],
                                  recordSizeLimitBytes: Option[Long]
                                )
 
@@ -139,10 +137,8 @@ object AppConfig {
 
   private val ingestConfig: ConfigValue[IngestConfig] =
     (
-      env("HYDRA_INGEST_ALTERNATE_ENABLED").as[Boolean].default(false),
-      env("HYDRA_INGEST_ALTERNATE_IGNORE_UA_STRINGS").as[Set[String]].default(Set.empty),
       env("HYDRA_INGEST_RECORD_SIZE_LIMIT_BYTES").as[Long].option
-    ).parMapN(IngestConfig)
+    ).map(IngestConfig)
 
   final case class TopicDeletionConfig(deleteTopicPassword: String)
 

--- a/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
+++ b/ingest/src/main/scala/hydra.ingest/http/IngestionEndpoint.scala
@@ -18,7 +18,7 @@ package hydra.ingest.http
 
 import akka.actor._
 import akka.http.scaladsl.model.{HttpRequest, StatusCode, StatusCodes}
-import akka.http.scaladsl.server.{ExceptionHandler, Rejection, Route}
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import cats.syntax.all._
 import fs2.kafka.{Header, Headers}
 import hydra.common.config.ConfigSupport._
@@ -29,44 +29,21 @@ import hydra.core.ingest.{CorrelationIdBuilder, HydraRequest, IngestionReport, R
 import hydra.core.marshallers.GenericError
 import hydra.core.monitor.HydraMetrics.addPromHttpMetric
 import hydra.core.protocol._
-import hydra.ingest.bootstrap.HydraIngestorRegistryClient
 import hydra.ingest.services.IngestionFlow.{AvroConversionAugmentedException, MissingTopicNameException, SchemaNotFoundAugmentedException}
 import hydra.ingest.services.IngestionFlowV2.V2IngestRequest
-import hydra.ingest.services.{IngestionFlow, IngestionFlowV2, IngestionHandlerGateway}
+import hydra.ingest.services.{IngestionFlow, IngestionFlowV2}
 import hydra.kafka.algebras.KafkaClientAlgebra.PublishError
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 
 import scala.collection.immutable.Map
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-
-/**
-  * Created by alexsilva on 12/22/15.
-  */
 class IngestionEndpoint[F[_]: Futurable](
-                                          alternateIngestFlowEnabled: Boolean,
                                           ingestionFlow: IngestionFlow[F],
-                                          ingestionV2Flow: IngestionFlowV2[F],
-                                          useOldIngestIfUAContains: Set[String],
-                                          requestHandlerPathName: Option[String] = None
+                                          ingestionV2Flow: IngestionFlowV2[F]
                                         )(implicit system: ActorSystem) extends RouteSupport with HydraIngestJsonSupport {
 
   import hydra.ingest.bootstrap.RequestFactories._
-
-  //for performance reasons, we give this endpoint its own instance of the gateway
-  private val registryPath =
-    HydraIngestorRegistryClient.registryPath(applicationConfig)
-
-  private val requestHandler = system.actorOf(
-    IngestionHandlerGateway.props(registryPath),
-    requestHandlerPathName.getOrElse("ingestion_Http_handler_gateway")
-  )
-
-  private val ingestTimeout = applicationConfig
-    .getDurationOpt("ingest.timeout")
-    .getOrElse(500.millis)
 
   override val route: Route =
     handleExceptions(exceptionHandler("UnknownTopic")) {
@@ -93,13 +70,6 @@ class IngestionEndpoint[F[_]: Futurable](
   }
 
   private def cId = CorrelationIdBuilder.generate()
-
-  private def useAlternateIngestFlow(request: HydraRequest): Boolean = {
-    request.metadata.find(e => e._1.equalsIgnoreCase("User-Agent")) match {
-      case Some(ua) if useOldIngestIfUAContains.exists(ua._2.startsWith) => false
-      case _ => true
-    }
-  }
 
   private def getV2ReponseCode(e: Throwable): (StatusCode, Option[String]) = e match {
     case PublishError.Timeout => (StatusCodes.RequestTimeout, None)
@@ -140,7 +110,7 @@ class IngestionEndpoint[F[_]: Futurable](
       }
     }
 
-  private def sendAltFlow(hydraRequest: HydraRequest,topic: String): Route = {
+  private def publishFlow(hydraRequest: HydraRequest,topic: String): Route = {
     extractExecutionContext { implicit ec =>
       onComplete(Futurable[F].unsafeToFuture(ingestionFlow.ingest(hydraRequest))) {
         case Success(_) =>
@@ -190,19 +160,8 @@ class IngestionEndpoint[F[_]: Futurable](
         onSuccess(createRequest[HttpRequest](cIdOpt.getOrElse(cId), req)) { hydraRequest =>
           val topic = hydraRequest.metadataValue(HYDRA_KAFKA_TOPIC_PARAM).getOrElse("UnknownTopic")
           handleExceptions(exceptionHandler(topic)) {
-            if (alternateIngestFlowEnabled && useAlternateIngestFlow(hydraRequest)) {
-              sendAltFlow(hydraRequest,topic)
-            } else {
-              log.warn("Old ingest flow being used for request: {}", hydraRequest)
-              imperativelyComplete { ctx =>
-                requestHandler ! InitiateHttpRequest(
-                  hydraRequest,
-                  ingestTimeout,
-                  ctx
-                )
-              }
+            publishFlow(hydraRequest,topic)
           }
-        }
       }
     }
   }
@@ -226,5 +185,3 @@ class IngestionEndpoint[F[_]: Futurable](
         }
   }
 }
-
-case object DeleteDirectiveNotAllowedRejection extends Rejection

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -47,10 +47,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
       new ConsumerGroupsEndpoint(algebras.consumerGroups).route ~
       new IngestorRegistryEndpoint().route ~
       new IngestionWebSocketEndpoint().route ~
-      new IngestionEndpoint(cfg.ingestConfig.alternateIngestEnabled,
-                            programs.ingestionFlow,
-                            programs.ingestionFlowV2,
-                            cfg.ingestConfig.useOldIngestIfUAContains).route ~
+      new IngestionEndpoint(programs.ingestionFlow, programs.ingestionFlowV2).route ~
       new TopicsEndpoint(consumerProxy)(system.dispatcher).route ~
       new TopicDeletionEndpoint(programs.topicDeletion,cfg.topicDeletionConfig.deleteTopicPassword).route ~
       HealthEndpoint.route ~

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
@@ -1,24 +1,18 @@
 package hydra.ingest.http
 
-import akka.actor.{Actor, Props}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{RawHeader, `User-Agent`}
 import akka.http.scaladsl.server.{MethodRejection, MissingHeaderRejection, RequestEntityExpectedRejection, Route}
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.{TestActorRef, TestKit}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.testkit.TestKit
 import cats.effect.{Concurrent, ContextShift, IO}
 import hydra.avro.registry.SchemaRegistry
-import hydra.common.util.ActorUtils
 import hydra.core.ingest.RequestParams
-import RequestParams._
+import hydra.core.ingest.RequestParams._
 import hydra.core.marshallers.GenericError
-import hydra.ingest.IngestorInfo
 import hydra.ingest.services.{IngestionFlow, IngestionFlowV2}
-import hydra.ingest.services.IngestorRegistry.{FindAll, FindByName, LookupResult}
-import hydra.ingest.test.TestIngestor
 import hydra.kafka.algebras.KafkaClientAlgebra
 import org.apache.avro.SchemaBuilder
-import org.joda.time.DateTime
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -31,39 +25,24 @@ final class IngestionEndpointSpec
     with ScalatestRouteTest
     with HydraIngestJsonSupport {
 
-  private implicit val timeout = RouteTestTimeout(10.seconds)
-  val probe = system.actorOf(Props[TestIngestor])
-
-  val ingestorInfo =
-    IngestorInfo(ActorUtils.actorName(probe), "test", probe.path, DateTime.now)
-
-  val registry = TestActorRef(
-    new Actor {
-      override def receive = {
-        case FindByName(name) if name == "tester" =>
-          sender ! LookupResult(Seq(ingestorInfo))
-        case FindByName(name) if name == "error" =>
-          throw new IllegalArgumentException("RAR")
-        case FindByName(_) => sender ! LookupResult(Seq.empty)
-        case FindAll       => sender ! LookupResult(Seq(ingestorInfo))
-      }
-    },
-    "ingestor_registry"
-  ).underlyingActor
-
   private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   private implicit val concurrentEffect: Concurrent[IO] = IO.ioConcurrentEffect
 
   import scalacache.Mode
   implicit val mode: Mode[IO] = scalacache.CatsEffect.modes.async
-  private val ingestRoute = new IngestionEndpoint(
-    false,
-    new IngestionFlow[IO](SchemaRegistry.test[IO].unsafeRunSync, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal"),
-    new IngestionFlowV2[IO](SchemaRegistry.test[IO].unsafeRunSync, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal"),
-    Set.empty
-  ).route
+  private val ingestRoute = {
+    val simpleSchema = SchemaBuilder.record("test").fields.requiredInt("test").endRecord()
+    val schemaReg =(for {
+      sr <- SchemaRegistry.test[IO]
+      _ <- sr.registerSchema("testtopic-value", simpleSchema)
+    } yield sr).unsafeRunSync
+    new IngestionEndpoint(
+      new IngestionFlow[IO](schemaReg, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal"),
+      new IngestionFlowV2[IO](SchemaRegistry.test[IO].unsafeRunSync, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal")
+    ).route
+  }
 
-  override def afterAll = {
+  override def afterAll: Unit = {
     super.afterAll()
     TestKit.shutdownActorSystem(
       system,
@@ -83,11 +62,8 @@ final class IngestionEndpointSpec
       _ <- schemaRegistry.registerSchema("dvs.blah.blah-value", simpleSchema)
     } yield {
       new IngestionEndpoint(
-        true,
         new IngestionFlow[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal"),
-        new IngestionFlowV2[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal"),
-        Set("Segment"),
-        Some("alt-test-request-handler")
+        new IngestionFlowV2[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal")
       ).route
     }).unsafeRunSync()
   }
@@ -112,22 +88,15 @@ final class IngestionEndpointSpec
 
     "initiates a delete request" in {
       val key = RawHeader(RequestParams.HYDRA_RECORD_KEY_PARAM, "test")
-      Delete("/ingest").withHeaders(key) ~> ingestRoute ~> check {
-        response.status.intValue() shouldBe 200 //todo: should we support a 204?
+      val topic = RawHeader(RequestParams.HYDRA_KAFKA_TOPIC_PARAM, "testtopic")
+      Delete("/ingest").withHeaders(key, topic) ~> ingestRoute ~> check {
+        response.status.intValue() shouldBe 200
       }
     }
 
     "rejects a delete request without a key" in {
       Delete("/ingest") ~> ingestRoute ~> check {
         rejection shouldEqual MissingHeaderRejection("hydra-record-key")
-      }
-    }
-
-    "publishes to a target ingestor" in {
-      val ingestor = RawHeader(RequestParams.HYDRA_INGESTOR_PARAM, "tester")
-      val request = Post("/ingest", "payload").withHeaders(ingestor)
-      request ~> ingestRoute ~> check {
-        status shouldBe StatusCodes.OK
       }
     }
 
@@ -152,20 +121,9 @@ final class IngestionEndpointSpec
     }
 
     "broadcasts a request" in {
-      val request = Post("/ingest", "payload")
+      val kafkaTopic = RawHeader(HYDRA_KAFKA_TOPIC_PARAM, "testtopic")
+      val request = Post("/ingest", """{"test": 2020}""").withHeaders(kafkaTopic)
       request ~> ingestRoute ~> check {
-        status shouldBe StatusCodes.OK
-      }
-    }
-
-
-    "publishes to a target ingestor for UA in provided Set" in {
-      val ingestor = RawHeader(RequestParams.HYDRA_INGESTOR_PARAM, "tester")
-      val userAgent = `User-Agent`("Segment.com")
-      val kafkaTopic = RawHeader(HYDRA_KAFKA_TOPIC_PARAM, "my_topic")
-
-      val request = Post("/ingest", "payload").withHeaders(ingestor, userAgent, kafkaTopic)
-      request ~> ingestRouteAlt ~> check {
         status shouldBe StatusCodes.OK
       }
     }


### PR DESCRIPTION
This PR is not to entirely remove the old ingest flow code, but rather just to remove any references to it. Another PR will be coming after this one to actually remove it entirely. I figured it was better to break it up so there were fewer variables at play in each deployment."
