### PR TITLE
Support V1 Topic Creation on App Boot

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/app/Main.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/Main.scala
@@ -81,7 +81,8 @@ object Main extends IOApp with ConfigSupport with LoggingAdapter {
           .make[IO](config)
         programs <- Programs.make[IO](config, algebras)
         bootstrap <- Bootstrap
-          .make[IO](programs.createTopic, config.metadataTopicsConfig, config.dvsConsumersTopicConfig, config.consumerOffsetsOffsetsTopicConfig)
+          .make[IO](programs.createTopic, config.metadataTopicsConfig,
+           config.dvsConsumersTopicConfig, config.consumerOffsetsOffsetsTopicConfig, algebras.kafkaAdmin)
         _ <- actorsIO()
         _ <- bootstrap.bootstrapAll
         routes <- Routes.make[IO](programs, algebras, config)

--- a/ingest/src/main/scala/hydra.ingest/app/Main.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/Main.scala
@@ -81,7 +81,7 @@ object Main extends IOApp with ConfigSupport with LoggingAdapter {
           .make[IO](config)
         programs <- Programs.make[IO](config, algebras)
         bootstrap <- Bootstrap
-          .make[IO](programs.createTopic, config.v2MetadataTopicConfig, config.dvsConsumersTopicConfig, config.consumerOffsetsOffsetsTopicConfig)
+          .make[IO](programs.createTopic, config.metadataTopicsConfig, config.dvsConsumersTopicConfig, config.consumerOffsetsOffsetsTopicConfig)
         _ <- actorsIO()
         _ <- bootstrap.bootstrapAll
         routes <- Routes.make[IO](programs, algebras, config)

--- a/ingest/src/main/scala/hydra.ingest/modules/Algebras.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Algebras.scala
@@ -25,10 +25,10 @@ object Algebras {
       )
       kafkaAdmin <- KafkaAdminAlgebra.live[F](config.createTopicConfig.bootstrapServers)
       kafkaClient <- KafkaClientAlgebra.live[F](config.createTopicConfig.bootstrapServers, schemaRegistry, config.ingestConfig.recordSizeLimitBytes)
-      metadata <- MetadataAlgebra.make[F](config.v2MetadataTopicConfig.topicName.value,
-        config.v2MetadataTopicConfig.consumerGroup, kafkaClient, schemaRegistry, config.v2MetadataTopicConfig.createOnStartup)
+      metadata <- MetadataAlgebra.make[F](config.metadataTopicsConfig.topicNameV2.value,
+        config.metadataTopicsConfig.consumerGroup, kafkaClient, schemaRegistry, config.metadataTopicsConfig.createV2OnStartup)
       consumerGroups <- ConsumerGroupsAlgebra.make[F](config.consumerGroupsAlgebraConfig.kafkaInternalConsumerGroupsTopic,
         config.dvsConsumersTopicConfig.topicName, config.consumerOffsetsOffsetsTopicConfig.topicName, config.createTopicConfig.bootstrapServers,
-        config.v2MetadataTopicConfig.consumerGroup, config.consumerGroupsAlgebraConfig.commonConsumerGroup, kafkaClient, kafkaAdmin, schemaRegistry)
+        config.metadataTopicsConfig.consumerGroup, config.consumerGroupsAlgebraConfig.commonConsumerGroup, kafkaClient, kafkaAdmin, schemaRegistry)
     } yield new Algebras[F](schemaRegistry, kafkaAdmin, kafkaClient, metadata, consumerGroups)
 }

--- a/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
@@ -11,22 +11,36 @@ import hydra.ingest.app.AppConfig.{ConsumerOffsetsOffsetsTopicConfig, DVSConsume
 import hydra.kafka.model._
 import hydra.kafka.programs.CreateTopicProgram
 import hydra.kafka.util.KafkaUtils.TopicDetails
+import hydra.kafka.algebras.KafkaAdminAlgebra
 
 final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
     createTopicProgram: CreateTopicProgram[F],
     cfg: MetadataTopicsConfig,
     dvsConsumersTopicConfig: DVSConsumersTopicConfig,
-    cooTopicConfig: ConsumerOffsetsOffsetsTopicConfig
+    cooTopicConfig: ConsumerOffsetsOffsetsTopicConfig,
+    kafkaAdmin: KafkaAdminAlgebra[F]
 ) {
 
   def bootstrapAll: F[Unit] =
     for {
-      _ <- bootstrapMetadataTopic
+      _ <- bootstrapMetadataTopicV2
+      _ <- bootstrapMetadataTopicV1
       _ <- bootstrapDVSConsumersTopic
       _ <- bootstrapConsumerOffsetsOffsetsTopic
     } yield ()
 
-  private def bootstrapMetadataTopic: F[Unit] =
+  private def bootstrapMetadataTopicV1: F[Unit] = {
+    if (cfg.createV1OnStartup) {
+      kafkaAdmin.createTopic(
+        cfg.topicNameV1.value,
+        TopicDetails(cfg.numPartitions, cfg.replicationFactor, Map("cleanup.policy" -> "compact"))
+      )
+    } else {
+      Monad[F].unit
+    }
+  }
+
+  private def bootstrapMetadataTopicV2: F[Unit] =
     if (cfg.createV2OnStartup) {
       TopicMetadataV2.getSchemas[F].flatMap { schemas =>
         createTopicProgram.createTopic(
@@ -106,8 +120,9 @@ object Bootstrap {
       createTopicProgram: CreateTopicProgram[F],
       metadataTopicsConfig: MetadataTopicsConfig,
       consumersTopicConfig: DVSConsumersTopicConfig,
-      consumerOffsetsOffsetsTopicConfig: ConsumerOffsetsOffsetsTopicConfig
+      consumerOffsetsOffsetsTopicConfig: ConsumerOffsetsOffsetsTopicConfig,
+      kafkaAdmin: KafkaAdminAlgebra[F]
   ): F[Bootstrap[F]] = Sync[F].delay {
-    new Bootstrap[F](createTopicProgram, metadataTopicsConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig)
+    new Bootstrap[F](createTopicProgram, metadataTopicsConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig, kafkaAdmin)
   }
 }

--- a/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
@@ -26,7 +26,7 @@ final class Programs[F[_]: Logger: Sync: Timer: Mode] private(
     algebras.kafkaAdmin,
     algebras.kafkaClient,
     retryPolicy,
-    cfg.v2MetadataTopicConfig.topicName,
+    cfg.metadataTopicsConfig.topicNameV2,
     algebras.metadata
   )
 

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -18,7 +18,7 @@ final class Routes[F[_]: Sync: Futurable] private(programs: Programs[F], algebra
                                                  (implicit system: ActorSystem) extends RouteConcatenation with ConfigSupport {
 
   private implicit val ec: ExecutionContext = system.dispatcher
-  private val bootstrapEndpointV2 = if (cfg.v2MetadataTopicConfig.createV2TopicsEnabled) {
+  private val bootstrapEndpointV2 = if (cfg.metadataTopicsConfig.createV2TopicsEnabled) {
     val topicDetails =
       TopicDetails(
         cfg.createTopicConfig.defaultNumPartions,

--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, IO, Sync, Timer}
 import cats.syntax.all._
 import fs2.kafka.Headers
 import hydra.avro.registry.SchemaRegistry
-import hydra.ingest.app.AppConfig.{ConsumerOffsetsOffsetsTopicConfig, DVSConsumersTopicConfig, V2MetadataTopicConfig}
+import hydra.ingest.app.AppConfig.{ConsumerOffsetsOffsetsTopicConfig, DVSConsumersTopicConfig, MetadataTopicsConfig}
 import hydra.kafka.algebras.KafkaAdminAlgebra.Topic
 import hydra.kafka.algebras.KafkaClientAlgebra.{ConsumerGroup, Offset, Partition, PublishError, PublishResponse, TopicName}
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
@@ -35,7 +35,7 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
   private val cooTopicSubject = Subject.createValidated("dvs.consumer-offsets-offsets").get
 
   private def createTestCase(
-      metadataConfig: V2MetadataTopicConfig,
+      metadataConfig: MetadataTopicsConfig,
       consumersTopicConfig: DVSConsumersTopicConfig,
       consumerOffsetsOffsetsTopicConfig: ConsumerOffsetsOffsetsTopicConfig
 
@@ -85,9 +85,11 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
 
     "create the metadata topic, consumers topic, and consumerOffsetsOffsets topic" in {
       val config =
-        V2MetadataTopicConfig(
+        MetadataTopicsConfig(
+          Subject.createValidated("dvs.does.not.matter").get,
           metadataSubject,
-          createOnStartup = true,
+          createV1OnStartup = false,
+          createV2OnStartup = true,
           createV2TopicsEnabled = true,
           ContactMethod.create("test@test.com").get,
           1,
@@ -112,9 +114,11 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
 
     "not create the metadata topic" in {
       val config =
-        V2MetadataTopicConfig(
+        MetadataTopicsConfig(
+          Subject.createValidated("dvs.does.not.matter").get,
           metadataSubject,
-          createOnStartup = false,
+          createV1OnStartup = false,
+          createV2OnStartup = false,
           createV2TopicsEnabled = false,
           ContactMethod.create("test@test.com").get,
           1,

--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -30,7 +30,8 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
   implicit private val cs: ContextShift[IO] = IO.contextShift(concurrent.ExecutionContext.global)
   implicit private val c: ConcurrentEffect[IO] = IO.ioConcurrentEffect
 
-  private val metadataSubject = Subject.createValidated("dvs.metadata").get
+  private val metadataSubjectV1 = Subject.createValidated("dvs.metadata.v1").get
+  private val metadataSubjectV2 = Subject.createValidated("dvs.metadata").get
   private val consumersTopicSubject = Subject.createValidated("dvs.consumers-topic").get
   private val cooTopicSubject = Subject.createValidated("dvs.consumer-offsets-offsets").get
 
@@ -46,21 +47,22 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
       kafkaAdmin <- KafkaAdminAlgebra.test[IO]
       ref <- Ref[IO].of(List.empty[(GenericRecord, Option[GenericRecord], Option[Headers])])
       kafkaClient = new TestKafkaClientAlgebraWithPublishTo(ref)
-      metadata <- MetadataAlgebra.make(metadataSubject.value, "consumer_group",kafkaClient, schemaRegistry, consumeMetadataEnabled = true)
+      metadata <- MetadataAlgebra.make(metadataSubjectV2.value, "consumer_group",kafkaClient, schemaRegistry, consumeMetadataEnabled = true)
       c = new CreateTopicProgram[IO](
         schemaRegistry,
         kafkaAdmin,
         kafkaClient,
         retry,
-        metadataSubject,
+        metadataSubjectV2,
         metadata
       )
-      boot <- Bootstrap.make[IO](c, metadataConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig)
+      boot <- Bootstrap.make[IO](c, metadataConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig, kafkaAdmin)
       _ <- boot.bootstrapAll
-      topicCreated <- kafkaAdmin.describeTopic(metadataSubject.value)
+      topicCreated <- kafkaAdmin.describeTopic(metadataSubjectV2.value)
+      topicCreated1 <- kafkaAdmin.describeTopic(metadataSubjectV1.value)
       topicCreated2 <- kafkaAdmin.describeTopic(consumersTopicConfig.topicName.value)
       topicCreated3 <- kafkaAdmin.describeTopic(consumerOffsetsOffsetsTopicConfig.topicName.value)
-      topics = List(topicCreated, topicCreated2, topicCreated3).flatten
+      topics = List(topicCreated, topicCreated1, topicCreated2, topicCreated3).flatten
       schemasAdded <- schemaRegistry.getAllSubjects
       messagesPublished <- ref.get
     } yield (topics, schemasAdded, messagesPublished)
@@ -83,12 +85,12 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
         1
       )
 
-    "create the metadata topic, consumers topic, and consumerOffsetsOffsets topic" in {
+    "create the metadata topics, consumers topic, and consumerOffsetsOffsets topic" in {
       val config =
         MetadataTopicsConfig(
-          Subject.createValidated("dvs.does.not.matter").get,
-          metadataSubject,
-          createV1OnStartup = false,
+          metadataSubjectV1,
+          metadataSubjectV2,
+          createV1OnStartup = true,
           createV2OnStartup = true,
           createV2TopicsEnabled = true,
           ContactMethod.create("test@test.com").get,
@@ -99,10 +101,11 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
       createTestCase(config, consumersTopicConfig, consumerOffsetsTopicConfig)
         .map {
           case (topicsCreated, schemasAdded, messagesPublished) =>
-            topicsCreated should contain allOf(Topic(metadataSubject.value, 1), Topic(consumersTopicSubject.value, 1), Topic(cooTopicSubject.value, 1))
+            topicsCreated should contain allOf(Topic(metadataSubjectV1.value, 1), Topic(metadataSubjectV2.value, 1),
+              Topic(consumersTopicSubject.value, 1), Topic(cooTopicSubject.value, 1))
             schemasAdded should contain allOf (
-              metadataSubject.value + "-key",
-              metadataSubject.value + "-value",
+              metadataSubjectV2.value + "-key",
+              metadataSubjectV2.value + "-value",
               consumersTopicSubject.value + "-key",
               consumersTopicSubject.value + "-value",
               cooTopicSubject.value + "-key",
@@ -115,8 +118,8 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
     "not create the metadata topic" in {
       val config =
         MetadataTopicsConfig(
-          Subject.createValidated("dvs.does.not.matter").get,
-          metadataSubject,
+          metadataSubjectV1,
+          metadataSubjectV2,
           createV1OnStartup = false,
           createV2OnStartup = false,
           createV2TopicsEnabled = false,
@@ -129,10 +132,10 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
       createTestCase(config, consumersTopicConfig, consumerOffsetsTopicConfig)
         .map {
           case (topicsCreated, schemasAdded, messagesPublished) =>
-            topicsCreated should not contain Topic(metadataSubject.value, 1)
-            schemasAdded should contain noneOf (metadataSubject.value + "-key", metadataSubject.value + "-value")
+            topicsCreated should not contain Topic(metadataSubjectV2.value, 1)
+            schemasAdded should contain noneOf (metadataSubjectV2.value + "-key", metadataSubjectV2.value + "-value")
             val keySchema = TopicMetadataV2.getSchemas.unsafeRunSync().key
-            messagesPublished.flatMap(m => TopicMetadataV2Key.codec.decode(m._1, keySchema).toOption.map(_.subject)) should not contain metadataSubject
+            messagesPublished.flatMap(m => TopicMetadataV2Key.codec.decode(m._1, keySchema).toOption.map(_.subject)) should not contain metadataSubjectV2
         }
         .unsafeRunSync()
     }


### PR DESCRIPTION
The purpose of this PR is to allow us to enable `auto.create.topics.enable = false` inside of our docker compose environment. To do this, we need to create the v1 metadata topic manually on app boot.