### PR TITLE
Validate Topic Creation and Record Publishing For Mismatches

### DIFF
--- a/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
@@ -213,7 +213,7 @@ final class IngestionEndpointSpec
       }
     }
     "accept a complete request" in {
-      val request = Post("/v2/topics/dvs.blah.blah/records", HttpEntity(ContentTypes.`application/json`, """{"key":{"test": 1}, "value":{"test": 2}}"""))
+      val request = Post("/v2/topics/dvs.blah.blah/records", HttpEntity(ContentTypes.`application/json`, """{"key":{"test": 1}, "value":{"test": 1}}"""))
       request ~> Route.seal(ingestRouteAlt) ~> check {
         responseAs[String] shouldBe "{\"offset\":0,\"partition\":0}"
         status shouldBe StatusCodes.OK
@@ -221,7 +221,7 @@ final class IngestionEndpointSpec
     }
     "accept a request with correlationId header" in {
       val correlationId = RawHeader("ps-correlation-id", "th1s1ss0m3c0RR3l4t10n")
-      val request = Post("/v2/topics/dvs.blah.blah/records", HttpEntity(ContentTypes.`application/json`, """{"key":{"test": 1}, "value":{"test": 2}}""")).withHeaders(correlationId)
+      val request = Post("/v2/topics/dvs.blah.blah/records", HttpEntity(ContentTypes.`application/json`, """{"key":{"test": 1}, "value":{"test": 1}}""")).withHeaders(correlationId)
       request ~> Route.seal(ingestRouteAlt) ~> check {
         responseAs[String] shouldBe "{\"offset\":1,\"partition\":0}"
         status shouldBe StatusCodes.OK

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowV2Spec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowV2Spec.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import fs2.kafka.{Header, Headers}
 import hydra.avro.registry.SchemaRegistry
 import hydra.core.transport.ValidationStrategy
-import hydra.ingest.services.IngestionFlowV2.{KeyAndValueMismatchedValuesException, V2IngestRequest}
+import hydra.ingest.services.IngestionFlowV2.{KeyAndValueMismatch, KeyAndValueMismatchedValuesException, V2IngestRequest}
 import hydra.kafka.algebras.KafkaClientAlgebra
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
@@ -132,7 +132,7 @@ final class IngestionFlowV2Spec extends AnyFlatSpec with Matchers {
       .build()
     IngestionFlowV2.validateKeyAndValueSchemas(key, value.some) match {
       case Left(error) =>
-        error shouldBe KeyAndValueMismatchedValuesException
+        error shouldBe KeyAndValueMismatchedValuesException(KeyAndValueMismatch("id","12345","54321"):: Nil)
       case _ => fail("Failed to properly validate key and value")
     }
   }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -143,7 +143,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
         }
         if (mismatches.isEmpty) ().pure else Bracket[F, Throwable].raiseError(IncompatibleKeyAndValueFieldNames(mismatches))
     }
-    Resource.pure(containsMismatches)
+    Resource.liftF(containsMismatches)
   }
 
   def createTopic(
@@ -174,6 +174,6 @@ object CreateTopicProgram {
   final case class KeyAndValueMismatch(fieldName: String, keyFieldSchema: Schema, valueFieldSchema: Schema)
   final case class IncompatibleKeyAndValueFieldNames(errors: List[KeyAndValueMismatch]) extends
     RuntimeException(
-      errors.map(e => s"Field ${e.fieldName} has mismatched type in key: ${e.keyFieldSchema.toString} and value: ${e.valueFieldSchema.toString}").mkString + " Fields with same names in key and value schemas must have same type."
+      (List("Fields with same names in key and value schemas must have same type:", "Field Name\tKey Schema\tValue Schema") ++ errors.map(e => s"${e.fieldName}\t${e.keyFieldSchema.toString}\t${e.valueFieldSchema}")).mkString("\n")
     )
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -8,12 +8,15 @@ import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.{IncompatibleSchemaException, SchemaVersion}
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
-import hydra.kafka.model.{TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
+import hydra.kafka.model.{Schemas, TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
+import hydra.kafka.programs.CreateTopicProgram.{IncompatibleKeyAndValueFieldNames, KeyAndValueMismatch}
 import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.Logger
 import org.apache.avro.Schema
 import retry.syntax.all._
 import retry.{RetryDetails, RetryPolicy, _}
+
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 
 final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
                                                                                schemaRegistry: SchemaRegistry[F],
@@ -123,6 +126,26 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
     } yield ()
   }
 
+  private def validateKeyAndValueSchemas(schemas: Schemas, subject: Subject): Resource[F, Unit] = {
+    val containsMismatches: F[Unit] = kafkaAdmin.describeTopic(subject.value).flatMap {
+      case Some(_) => Bracket[F, Throwable].unit
+      case None =>
+        val keyFields = schemas.key.getFields.asScala.toList
+        val valueFields = schemas.value.getFields.asScala.toList
+        val mismatches = keyFields.flatMap{ k =>
+          valueFields.flatMap { v =>
+            if (k.name() == v.name() && !k.schema().equals(v.schema())) {
+              Some(KeyAndValueMismatch(k.name(), k.schema(), v.schema()))
+            } else {
+              None
+            }
+          }
+        }
+        if (mismatches.isEmpty) ().pure else Bracket[F, Throwable].raiseError(IncompatibleKeyAndValueFieldNames(mismatches))
+    }
+    Resource.pure(containsMismatches)
+  }
+
   def createTopic(
       topicName: Subject,
       createTopicRequest: TopicMetadataV2Request,
@@ -134,6 +157,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       Bracket[F, Throwable].raiseError(IncompatibleSchemaException("Must include Fields in Key"))
     } else {
       (for {
+        _ <- validateKeyAndValueSchemas(createTopicRequest.schemas, topicName)
         _ <- registerSchemas(
           topicName,
           createTopicRequest.schemas.key,
@@ -144,4 +168,12 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       } yield ()).use(_ => Bracket[F, Throwable].unit)
     }
   }
+}
+
+object CreateTopicProgram {
+  final case class KeyAndValueMismatch(fieldName: String, keyFieldSchema: Schema, valueFieldSchema: Schema)
+  final case class IncompatibleKeyAndValueFieldNames(errors: List[KeyAndValueMismatch]) extends
+    RuntimeException(
+      errors.map(e => s"Field ${e.fieldName} has mismatched type in key: ${e.keyFieldSchema.toString} and value: ${e.valueFieldSchema.toString}").mkString + " Fields with same names in key and value schemas must have same type."
+    )
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -65,7 +65,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       .void
   }
 
-  private def registerSchemas(
+  private[programs] def registerSchemas(
       subject: Subject,
       keySchema: Schema,
       valueSchema: Schema
@@ -77,7 +77,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
     )
   }
 
-  private def createTopicResource(
+  private[programs] def createTopicResource(
       subject: Subject,
       topicDetails: TopicDetails
   ): Resource[F, Unit] = {
@@ -101,7 +101,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       .void
   }
 
-  private def publishMetadata(
+  private[programs] def publishMetadata(
       topicName: Subject,
       createTopicRequest: TopicMetadataV2Request,
   ): F[Unit] = {


### PR DESCRIPTION
In V2, when publishers submit schemas where both key avro and value avro have a field with the same name, we now validate that the type is the same. When users publish records to this topic, we now validate that the values for any "same named fields" are the same.