### PR TITLE
Make sure the TopicMetadataEndpoint checks for the get verb before matching a route

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -109,11 +109,15 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
             } ~ createTopic(startTime)
           }
         } ~ pathPrefix("v2" / "topics") {
-          val startTime = Instant.now
-          getAllV2Metadata(startTime) ~
+          get {
+            val startTime = Instant.now
             pathPrefix(Segment) { topicName =>
               getV2Metadata(topicName, startTime)
+            } ~
+            pathEndOrSingleSlash {
+              getAllV2Metadata(startTime)
             }
+          }
         } ~ pathPrefix("v2" / "streams") {
           val startTime = Instant.now
           get {


### PR DESCRIPTION
This path was being matched when sending a DELETE request because the path is the same and this route def wasn't explicit with the verb that it is associated with. Almost gave Bill a heart attack when he sent a delete request in prod and the response included all v2 metadata.