### PR TITLE
Adding call to list consumer groups so it can be used for validating consumer group names are unique

### DIFF
--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -104,6 +104,8 @@ class TopicDeletionEndpointSpec extends Matchers with AnyWordSpecLike with Scala
           Sync[F].pure(Left(new KafkaDeleteTopicErrorList(NonEmptyList.fromList(
             topicNames.map(topic => KafkaDeleteTopicError(topic, new Exception("Unable to delete topic")))).get)))
       }
+
+      override def listConsumerGroups(): F[List[String]] = ???
     }
   }
 

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -100,6 +100,8 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
       override def deleteTopics(topicNames: List[String]): F[Either[KafkaDeleteTopicErrorList, Unit]] =
         Sync[F].pure(Left(new KafkaDeleteTopicErrorList( NonEmptyList.fromList(
           topicNames.map(topic => KafkaDeleteTopicError(topic, new Exception("Unable to delete topic")))).get)))
+
+      override def listConsumerGroups(): F[List[String]] = ???
     }
   }
 


### PR DESCRIPTION
Will just import this in kstreams and use it to check if consumer group names are unique when submitting a job. Alternatively, we could also consume the consumerGroups topic. I think that would be overkill for this situation though.