### PR TITLE
Fix bug with handling the parsing of default arrays, maps, and records

### DIFF
--- a/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
+++ b/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
@@ -120,7 +120,6 @@ public class JsonConverter<T extends GenericRecord> {
     public T convert(String json) throws IOException {
         try {
             //let's be proactive and fail fast with strict validation
-            mapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
             Map<String, Object> fields = mapper.readValue(json, Map.class);
             if (strictValidation) performStrictValidation(fields, baseSchema);
             return convert(fields, baseSchema);

--- a/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
+++ b/avro/src/main/java/com/pluralsight/hydra/avro/JsonConverter.java
@@ -15,6 +15,7 @@
 
 package com.pluralsight.hydra.avro;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.ClassUtil;
@@ -119,6 +120,7 @@ public class JsonConverter<T extends GenericRecord> {
     public T convert(String json) throws IOException {
         try {
             //let's be proactive and fail fast with strict validation
+            mapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
             Map<String, Object> fields = mapper.readValue(json, Map.class);
             if (strictValidation) performStrictValidation(fields, baseSchema);
             return convert(fields, baseSchema);
@@ -188,7 +190,7 @@ public class JsonConverter<T extends GenericRecord> {
                             value = defaultValue.asText();
                             break;
                         case MAP:
-                            Map<String, Object> fieldMap = mapper.readValue(defaultValue.asText(), Map.class);
+                            Map<String, Object> fieldMap = mapper.readValue(defaultValue.toString(), Map.class);
                             Map<String, Object> mvalue = Maps.newHashMap();
                             for (Map.Entry<String, Object> e : fieldMap.entrySet()) {
                                 mvalue.put(e.getKey(), typeConvert(e.getValue(), name, fieldSchema.getValueType()));
@@ -196,7 +198,7 @@ public class JsonConverter<T extends GenericRecord> {
                             value = mvalue;
                             break;
                         case ARRAY:
-                            List fieldArray = mapper.readValue(defaultValue.asText(), List.class);
+                            List fieldArray = mapper.readValue(defaultValue.toString(), List.class);
                             List lvalue = Lists.newArrayList();
                             for (Object elem : fieldArray) {
                                 lvalue.add(typeConvert(elem, name, fieldSchema.getElementType()));
@@ -204,7 +206,7 @@ public class JsonConverter<T extends GenericRecord> {
                             value = lvalue;
                             break;
                         case RECORD:
-                            Map<String, Object> fieldRec = mapper.readValue(defaultValue.asText(), Map.class);
+                            Map<String, Object> fieldRec = mapper.readValue(defaultValue.toString(), Map.class);
                             value = convert(fieldRec, fieldSchema);
                             break;
                         default:

--- a/avro/src/test/java/com/pluralsight/hydra/avro/JsonConverterTest.java
+++ b/avro/src/test/java/com/pluralsight/hydra/avro/JsonConverterTest.java
@@ -21,8 +21,11 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
+import scala.collection.immutable.List;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 
@@ -176,5 +179,26 @@ public class JsonConverterTest {
         String json = "{ \"field1\": 1, \"field2\": [true, true, false], \"field3\": {\"key\": \"value\"}," + " " +
                 "\"extra\": \"test\"}";
         jc.convert(json);
+    }
+
+    @Test
+    public void testDefaults() throws Exception {
+        Schema.Field field1 = new Schema.Field("arr", Schema.createArray(sc(Type.INT)), "", new ArrayList<Integer>());
+        Schema.Field field2 = new Schema.Field("map", Schema.createMap(sc(Type.STRING)), "", new HashMap<String, String>());
+        ArrayList<Schema.Field> fieldList = new ArrayList<Schema.Field>();
+        fieldList.add(sf("recField", Type.STRING));
+        HashMap<String, String> recordDefault = new HashMap<>();
+        recordDefault.put("recField", "default");
+        Schema.Field field3 = new Schema.Field(
+                "record",
+                Schema.createRecord("recordName", "doc", "namespace", false, fieldList),
+                "",
+                recordDefault
+        );
+        JsonConverter jc = new JsonConverter(sr(field1, field2, field3));
+        String json = "{}";
+        String expect = "{\"arr\": [], \"map\": {}, \"record\": {\"recField\": \"default\"}}";
+        GenericRecord r = jc.convert(json);
+        assertEquals(expect, r.toString());
     }
 }


### PR DESCRIPTION
There is a bug where if a user defines an array, map, or record in their schema and they give it a default - when they try to publish a record that does not include the field (and so goes to using the default) we get to this part of the code where it was using that asText and that would only work for valueNodes. Updated to use toString instead.