### PR TITLE
We had a 2 minute timeframe when users could send in a message after …

### DIFF
--- a/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
+++ b/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
@@ -238,7 +238,9 @@ object SchemaRegistry {
       //TODO: Test this
       override def getLatestSchemaBySubject(subject: String): F[Option[Schema]] = Sync[F].delay {
         Try {
-          new org.apache.avro.Schema.Parser().parse(schemaRegistryClient.getLatestSchemaMetadata(subject).getSchema)
+          val schema = schemaRegistryClient.getLatestSchemaMetadata(subject).getSchema
+          val parse = new org.apache.avro.Schema.Parser().parse(schema)
+          parse
         }.toOption
       }
 

--- a/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
+++ b/avro/src/main/scala/hydra/avro/registry/SchemaRegistry.scala
@@ -238,9 +238,7 @@ object SchemaRegistry {
       //TODO: Test this
       override def getLatestSchemaBySubject(subject: String): F[Option[Schema]] = Sync[F].delay {
         Try {
-          val schema = schemaRegistryClient.getLatestSchemaMetadata(subject).getSchema
-          val parse = new org.apache.avro.Schema.Parser().parse(schema)
-          parse
+          new org.apache.avro.Schema.Parser().parse(schemaRegistryClient.getLatestSchemaMetadata(subject).getSchema)
         }.toOption
       }
 

--- a/avro/src/main/scala/hydra/avro/resource/SchemaResourceLoader.scala
+++ b/avro/src/main/scala/hydra/avro/resource/SchemaResourceLoader.scala
@@ -188,5 +188,5 @@ object SchemaResourceLoader {
   // than max.schemas.per.subject.
   val schemaCache = GuavaCache[Schema]
 
-  final case class SchemaNotFoundException(subject: String) extends Exception(s"Schema not found for $subject")
+  final case class SchemaNotFoundException(subject: String) extends Exception(s"Schema not found for $subject\nThis means your topic was not registered with Schema Registry, you may need to check if this topic exists")
 }

--- a/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
@@ -2,6 +2,7 @@ package hydra.ingest.modules
 
 import cats.effect._
 import cats.syntax.all._
+import hydra.avro.util.SchemaWrapper
 import hydra.ingest.app.AppConfig.AppConfig
 import hydra.ingest.programs.TopicDeletionProgram
 import hydra.ingest.services.{IngestionFlow, IngestionFlowV2}
@@ -10,7 +11,8 @@ import hydra.kafka.programs.CreateTopicProgram
 import io.chrisdavenport.log4cats.Logger
 import retry.RetryPolicies._
 import retry.RetryPolicy
-import scalacache.Mode
+import scalacache.{Cache, Mode}
+import scalacache.guava.GuavaCache
 
 final class Programs[F[_]: Logger: Sync: Timer: Mode] private(
     cfg: AppConfig,
@@ -36,6 +38,8 @@ final class Programs[F[_]: Logger: Sync: Timer: Mode] private(
     algebras.kafkaClient,
     cfg.createTopicConfig.schemaRegistryConfig.fullUrl
   )
+
+  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
   val ingestionFlowV2: IngestionFlowV2[F] = new IngestionFlowV2[F](
     algebras.schemaRegistry,

--- a/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Routes.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.directives.RouteDirectives
 import akka.http.scaladsl.server.{Route, RouteConcatenation}
 import cats.effect.Sync
+import hydra.avro.util.SchemaWrapper
 import hydra.common.config.ConfigSupport
 import hydra.common.util.{ActorUtils, Futurable}
 import hydra.ingest.app.AppConfig.AppConfig
@@ -11,6 +12,8 @@ import hydra.ingest.http._
 import hydra.kafka.consumer.KafkaConsumerProxy
 import hydra.kafka.endpoints.{BootstrapEndpoint, BootstrapEndpointV2, ConsumerGroupsEndpoint, TagsEndpoint, TopicMetadataEndpoint, TopicsEndpoint}
 import hydra.kafka.util.KafkaUtils.TopicDetails
+import scalacache.Cache
+import scalacache.guava.GuavaCache
 
 import scala.concurrent.ExecutionContext
 

--- a/ingest/src/main/scala/hydra.ingest/services/IngestionFlowV2.scala
+++ b/ingest/src/main/scala/hydra.ingest/services/IngestionFlowV2.scala
@@ -25,13 +25,12 @@ import scala.util.{Failure, Try}
 final class IngestionFlowV2[F[_]: MonadError[*[_], Throwable]: Mode](
                                                                     schemaRegistry: SchemaRegistry[F],
                                                                     kafkaClient: KafkaClientAlgebra[F],
-                                                                    schemaRegistryBaseUrl: String) {
+                                                                    schemaRegistryBaseUrl: String)
+                                                                    (implicit guavaCache: Cache[SchemaWrapper]){
 
   import IngestionFlowV2._
   import hydra.avro.convert.StringToGenericRecord._
   import hydra.avro.convert.SimpleStringToGenericRecord._
-
-  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
   private def getSchema(subject: String): F[Schema] = {
     schemaRegistry.getLatestSchemaBySubject(subject)
@@ -58,7 +57,8 @@ final class IngestionFlowV2[F[_]: MonadError[*[_], Throwable]: Mode](
         Failure(AvroConversionAugmentedException(s"${e.getClass.getName}: ${e.getMessage} [$location]"))
       case e: IOException =>
         Failure(AvroConversionAugmentedException(s"${e.getClass.getName}: ${e.getMessage} [$location]"))
-      case e => Failure(e)
+      case e =>
+        Failure(e)
     }
     pf
   }

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.TestKit
 import cats.effect.{Concurrent, ContextShift, IO}
 import hydra.avro.registry.SchemaRegistry
+import hydra.avro.util.SchemaWrapper
 import hydra.core.ingest.RequestParams
 import hydra.core.ingest.RequestParams._
 import hydra.core.marshallers.GenericError
@@ -15,6 +16,8 @@ import hydra.kafka.algebras.KafkaClientAlgebra
 import org.apache.avro.SchemaBuilder
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import scalacache.Cache
+import scalacache.guava.GuavaCache
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -27,6 +30,7 @@ final class IngestionEndpointSpec
 
   private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   private implicit val concurrentEffect: Concurrent[IO] = IO.ioConcurrentEffect
+  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
   import scalacache.Mode
   implicit val mode: Mode[IO] = scalacache.CatsEffect.modes.async

--- a/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/TopicDeletionEndpointSpec.scala
@@ -17,9 +17,12 @@ import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit._
+import hydra.avro.util.SchemaWrapper
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import scalacache.Cache
+import scalacache.guava.GuavaCache
 
 import scala.concurrent.ExecutionContext
 
@@ -33,6 +36,8 @@ class TopicDeletionEndpointSpec extends Matchers with AnyWordSpecLike with Scala
   private val v2MetadataTopicName = Subject.createValidated("_test.V2.MetadataTopic").get
   private val v1MetadataTopicName = Subject.createValidated("_test.V1.MetadataTopic").get
   private val consumerGroup = "consumer groups"
+  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
+
 
   implicit private def unsafeLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] =
     Slf4jLogger.getLogger[F]

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import cats.implicits._
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
+import hydra.avro.util.SchemaWrapper
 import hydra.kafka.algebras.KafkaAdminAlgebra.{KafkaDeleteTopicError, KafkaDeleteTopicErrorList, LagOffsets, Offset, Topic, TopicAndPartition, TopicName}
 import hydra.kafka.algebras.MetadataAlgebra.TopicMetadataContainer
 import hydra.kafka.model.ContactMethod.Email
@@ -23,6 +24,8 @@ import hydra.kafka.programs.CreateTopicProgram
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import retry.{RetryPolicies, RetryPolicy}
+import scalacache.Cache
+import scalacache.guava.GuavaCache
 
 import scala.concurrent.ExecutionContext
 
@@ -168,6 +171,8 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
   private def getExpectedDeletedTopics(topicNames: List[String], topicNamesToDelete: List[String], kafkaTopicNamesToFail: List[String]): List[String] = {
     return topicNames.toSet.intersect(topicNamesToDelete.toSet).diff(kafkaTopicNamesToFail.toSet).toList
   }
+
+  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
   private def applyTestcase(kafkaAdminAlgebra: IO[KafkaAdminAlgebra[IO]],
                             schemaRegistry: IO[SchemaRegistry[IO]],

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -2,6 +2,7 @@ package hydra.ingest.programs
 
 import java.time.Instant
 
+import cats.MonadError
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.effect.{Bracket, Concurrent, ContextShift, IO, Sync, Timer}
@@ -13,7 +14,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import cats.implicits._
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
+import hydra.avro.resource.SchemaResourceLoader.SchemaNotFoundException
 import hydra.avro.util.SchemaWrapper
+import hydra.ingest.services.IngestionFlowV2.SchemaNotFoundAugmentedException
 import hydra.kafka.algebras.KafkaAdminAlgebra.{KafkaDeleteTopicError, KafkaDeleteTopicErrorList, LagOffsets, Offset, Topic, TopicAndPartition, TopicName}
 import hydra.kafka.algebras.MetadataAlgebra.TopicMetadataContainer
 import hydra.kafka.model.ContactMethod.Email
@@ -26,8 +29,13 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import retry.{RetryPolicies, RetryPolicy}
 import scalacache.Cache
 import scalacache.guava.GuavaCache
-
+import scalacache.memoization._
+import scalacache.modes.try_._
+import cats.MonadError
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
+import java.io.IOException
+import scalacache.Mode
 
 class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
   implicit private val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
@@ -174,6 +182,22 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
 
   implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
+  private def getSchema(sr: SchemaRegistry[IO], subject: String): IO[Schema] = {
+    sr.getLatestSchemaBySubject(subject)
+      .flatMap { maybeSchema =>
+        val schemaNotFound = SchemaNotFoundException(subject)
+        MonadError[IO, Throwable].fromOption(maybeSchema, SchemaNotFoundAugmentedException(schemaNotFound, subject))
+      }
+  }
+
+  implicit val mode: Mode[IO] = scalacache.CatsEffect.modes.async
+
+  private def getSchemaWrapper(sr: SchemaRegistry[IO], subject: String): IO[SchemaWrapper] = memoizeF[IO, SchemaWrapper](Some(2.minutes)) {
+    getSchema(sr, subject + "-value").map { sch =>
+      SchemaWrapper.from(sch)
+    }
+  }
+
   private def applyTestcase(kafkaAdminAlgebra: IO[KafkaAdminAlgebra[IO]],
                             schemaRegistry: IO[SchemaRegistry[IO]],
                             v1TopicNames: List[String],
@@ -187,7 +211,6 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
     (for {
       // For v2 topics we need to write the metadata to the v2MetadataTopic because the topic deletion attempts to lookup
       // the v2 metadata and uses the results to determine if we are deleting a v1 or v2 topic.
-
       kafkaAdmin <- kafkaAdminAlgebra
       schemaAlgebra <- schemaRegistry
       kafkaClientAlgebra <- KafkaClientAlgebra.test[IO]
@@ -202,6 +225,8 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
       _ <- registerTopics(v2TopicNames, schemaAlgebra, registerKey, upgrade=false)
       // upgrade any topics needed
       _ <- registerTopics(List(upgradeTopic._1), schemaAlgebra, registerKey, upgradeTopic._2)
+      // add Schemas to Cache
+      _ <- (v1TopicNames++v2TopicNames).traverse{topic => getSchemaWrapper(schemaAlgebra, topic)}
       // delete all given topics
       errors <-  new TopicDeletionProgram[IO](
         kafkaAdmin,
@@ -251,34 +276,43 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
 
   it should "Delete a Single Topic from Kafka value only" in {
     applyGoodTestcase(List("topic1"), List.empty, List("topic1"))
+    guavaCache.get("topic1").unsafeRunSync() shouldBe None
   }
 
   it should "Delete a Single Topic from Multiple topics in Kafka value only" in {
     applyGoodTestcase(twoTopics, List.empty, List("topic1"))
+    twoTopics.map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Delete Multiple Topics from Kafka value only" in {
     applyGoodTestcase(twoTopics, List.empty, twoTopics)
+    twoTopics.map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Delete a Single Topic from Multiple topics in Kafka key and value" in {
     applyGoodTestcase(twoTopics, List.empty, List("topic1"), registerKey = true)
+    twoTopics.map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Delete a single v2 topic" in {
     applyGoodTestcase(List.empty, List("_topic1.name", "_topic2.name"), List("_topic1.name"), registerKey = true)
+    guavaCache.get("_topic1.name").unsafeRunSync() shouldBe None
   }
 
   it should "Delete multiple v2 topics" in {
     applyGoodTestcase(List.empty, List("_topic1.name", "_topic2.name"), List("_topic1.name", "_topic2.name"), registerKey = true)
+    List("_topic1.name", "_topic2.name").map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Delete a v1 and v2 topic" in {
     applyGoodTestcase(twoTopics, List("_topic1.name", "_topic2.name"), List("_topic1.name", "_topic2.name"), registerKey = true)
+    List("_topic1.name", "_topic2.name").map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
+    twoTopics.map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Delete Multiple Topics from Kafka key and value" in {
     applyGoodTestcase(twoTopics, List.empty, twoTopics, registerKey = true)
+    twoTopics.map(topic => guavaCache.get(topic).unsafeRunSync() shouldBe None)
   }
 
   it should "Return a KafkaDeletionError if the topic does not exist" in {

--- a/ingest/src/test/scala/hydra/ingest/services/IngestionFlowV2Spec.scala
+++ b/ingest/src/test/scala/hydra/ingest/services/IngestionFlowV2Spec.scala
@@ -4,6 +4,7 @@ import cats.effect.{Concurrent, ContextShift, IO}
 import cats.syntax.all._
 import fs2.kafka.{Header, Headers}
 import hydra.avro.registry.SchemaRegistry
+import hydra.avro.util.SchemaWrapper
 import hydra.core.transport.ValidationStrategy
 import hydra.ingest.services.IngestionFlowV2.{KeyAndValueMismatch, KeyAndValueMismatchedValuesException, V2IngestRequest}
 import hydra.kafka.algebras.KafkaClientAlgebra
@@ -12,6 +13,8 @@ import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scalacache.Cache
+import scalacache.guava.GuavaCache
 
 import scala.concurrent.ExecutionContext
 
@@ -34,6 +37,8 @@ final class IngestionFlowV2Spec extends AnyFlatSpec with Matchers {
 
   private val testValSchema: Schema = SchemaBuilder.record("TestRecord")
     .fields().requiredBoolean("testField").endRecord()
+
+  implicit val guavaCache: Cache[SchemaWrapper] = GuavaCache[SchemaWrapper]
 
   private def ingest(request: V2IngestRequest, altValueSchema: Option[Schema] = None): IO[KafkaClientAlgebra[IO]] = for {
     schemaRegistry <- SchemaRegistry.test[IO]


### PR DESCRIPTION
…a topic was deleted which would cause a spike in latency, this removes all entries in the cache which allows the topic to be fully deleted