### PR TITLE
adding additional consumer information to endpoint

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/algebras/KafkaAdminAlgebra.scala
@@ -13,6 +13,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import spray.json.RootJsonFormat
 
 import scala.util.control.NoStackTrace
 
@@ -93,9 +94,9 @@ object KafkaAdminAlgebra {
     def apply(t: TopicPartition): TopicAndPartition =
       new TopicAndPartition(t.topic, t.partition)
   }
-  final case class Offset(value: Long) extends AnyVal
+  final case class Offset(value: Long)
   object Offset {
-    def apply(o: OffsetAndMetadata): Offset =
+    def fromOffsetAndMetadata(o: OffsetAndMetadata): Offset =
       new Offset(o.offset)
   }
   final case class LagOffsets(latest: Offset, group: Offset)
@@ -150,7 +151,7 @@ object KafkaAdminAlgebra {
 
       override def getConsumerGroupOffsets(consumerGroup: String): F[Map[TopicAndPartition, Offset]] =
         getAdminClientResource.use(_.listConsumerGroupOffsets(consumerGroup)
-          .partitionsToOffsetAndMetadata.map(_.map(r => TopicAndPartition(r._1) -> Offset(r._2))))
+          .partitionsToOffsetAndMetadata.map(_.map(r => TopicAndPartition(r._1) -> Offset.fromOffsetAndMetadata(r._2))))
 
       override def getLatestOffsets(topic: TopicName): F[Map[TopicAndPartition, Offset]] = {
         getConsumerResource.use { consumerMaybe =>

--- a/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
@@ -1,11 +1,11 @@
 package hydra.kafka.marshallers
 
 import java.time.Instant
-
+import spray.json._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import hydra.kafka.algebras.ConsumerGroupsAlgebra
-import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, TopicConsumers}
-import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
+import hydra.kafka.algebras.{ConsumerGroupsAlgebra, KafkaAdminAlgebra}
+import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, PartitionOffset, TopicConsumers}
+import hydra.kafka.algebras.KafkaAdminAlgebra.{LagOffsets, Offset, TopicAndPartition}
 
 trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport {
 
@@ -15,7 +15,11 @@ trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport
     override def read(json: JsValue): Instant = Instant.now()
   }
 
-  implicit val topicFormat: RootJsonFormat[ConsumerGroupsAlgebra.Topic] = jsonFormat2(ConsumerGroupsAlgebra.Topic)
+  implicit val topicAndPartition: RootJsonFormat[TopicAndPartition] = jsonFormat2(TopicAndPartition.apply)
+  implicit val offset: JsonFormat[Offset] = jsonFormat1(Offset.apply)
+  implicit val lag: RootJsonFormat[LagOffsets] = jsonFormat2(LagOffsets.apply)
+  implicit val partitionOffset: RootJsonFormat[PartitionOffset] = jsonFormat4(PartitionOffset.apply)
+  implicit val topicFormat: RootJsonFormat[ConsumerGroupsAlgebra.Topic] = jsonFormat3(ConsumerGroupsAlgebra.Topic)
   implicit val consumerFormat: RootJsonFormat[ConsumerGroupsAlgebra.Consumer] = jsonFormat2(ConsumerGroupsAlgebra.Consumer)
 
   implicit val consumerTopicsFormat: RootJsonFormat[ConsumerTopics] = jsonFormat2(ConsumerTopics)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
@@ -23,12 +23,13 @@ trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport
 
   implicit object topicFormat extends RootJsonFormat[Topic] {
     override def write(topic: Topic): JsValue = JsObject(List(
-      Some("topicName", JsString(topic.topicName)),
-      Some("lastCommit", InstantFormat.write(topic.lastCommit)),
-      if (topic.offsetInformation.isEmpty) None else Some("offsetInformation" -> JsArray(topic.offsetInformation.sortBy(_.partition).map(partitionOffset.write).toVector))
+      Some("topicName" -> JsString(topic.topicName)),
+      Some("lastCommit" -> InstantFormat.write(topic.lastCommit)),
+      if (topic.offsetInformation.isEmpty) None else Some("offsetInformation" -> JsArray(topic.offsetInformation.sortBy(_.partition).map(partitionOffset.write).toVector)),
+      if (topic.totalLag.isEmpty) None else Some("totalLag" -> JsNumber(topic.totalLag.getOrElse(0L)))
     ).flatten.toMap)
 
-    override def read(json: JsValue): Topic = jsonFormat3(Topic.apply).read(json)
+    override def read(json: JsValue): Topic = jsonFormat4(Topic.apply).read(json)
   }
 
   implicit val consumerFormat: RootJsonFormat[ConsumerGroupsAlgebra.Consumer] = jsonFormat2(ConsumerGroupsAlgebra.Consumer)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/marshallers/ConsumerGroupMarshallers.scala
@@ -1,10 +1,11 @@
 package hydra.kafka.marshallers
 
 import java.time.Instant
-import spray.json._
+import spray.json.{RootJsonFormat, _}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import hydra.core.transport.AckStrategy
 import hydra.kafka.algebras.{ConsumerGroupsAlgebra, KafkaAdminAlgebra}
-import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, PartitionOffset, TopicConsumers}
+import hydra.kafka.algebras.ConsumerGroupsAlgebra.{ConsumerTopics, PartitionOffset, Topic, TopicConsumers}
 import hydra.kafka.algebras.KafkaAdminAlgebra.{LagOffsets, Offset, TopicAndPartition}
 
 trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport {
@@ -19,7 +20,17 @@ trait ConsumerGroupMarshallers extends DefaultJsonProtocol with SprayJsonSupport
   implicit val offset: JsonFormat[Offset] = jsonFormat1(Offset.apply)
   implicit val lag: RootJsonFormat[LagOffsets] = jsonFormat2(LagOffsets.apply)
   implicit val partitionOffset: RootJsonFormat[PartitionOffset] = jsonFormat4(PartitionOffset.apply)
-  implicit val topicFormat: RootJsonFormat[ConsumerGroupsAlgebra.Topic] = jsonFormat3(ConsumerGroupsAlgebra.Topic)
+
+  implicit object topicFormat extends RootJsonFormat[Topic] {
+    override def write(topic: Topic): JsValue = JsObject(List(
+      Some("topicName", JsString(topic.topicName)),
+      Some("lastCommit", InstantFormat.write(topic.lastCommit)),
+      if (topic.offsetInformation.isEmpty) None else Some("offsetInformation" -> JsArray(topic.offsetInformation.sortBy(_.partition).map(partitionOffset.write).toVector))
+    ).flatten.toMap)
+
+    override def read(json: JsValue): Topic = jsonFormat3(Topic.apply).read(json)
+  }
+
   implicit val consumerFormat: RootJsonFormat[ConsumerGroupsAlgebra.Consumer] = jsonFormat2(ConsumerGroupsAlgebra.Consumer)
 
   implicit val consumerTopicsFormat: RootJsonFormat[ConsumerTopics] = jsonFormat2(ConsumerTopics)


### PR DESCRIPTION
This adds offset information to the individual consumer endpoint. All other endpoints remain the same, however for the individual consumer you will be able to now see: 

1. Consumer Group Name (given by URL)
2. Last Commit timestamp
3. Group Offset for every partition
4. Latest Offset for every partition
5. Partition Lag for every partition
6. Topic(s) that the consumer is/are subscribed to
7. The total lag for every topic