### PR TITLE
Add metadata validation rewrite

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -169,11 +169,11 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
                       val req = TopicMetadataV2Request.fromMetadataOnlyRequest(schemas, mor)
                       onComplete(
                         Futurable[F].unsafeToFuture(createTopicProgram
-                          .publishMetadata(t, req))
+                          .createTopicFromMetadataOnly(t, req))
                       ) {
                         case Failure(exception) =>
                           addHttpMetric(topic, StatusCodes.InternalServerError, "/v2/metadata", startTime, method.value)
-                          complete(StatusCodes.InternalServerError, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
+                          complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
                         case Success(value) =>
                           addHttpMetric(topic, StatusCodes.OK, "/v2/metadata", startTime, method.value)
                           complete(StatusCodes.OK)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -176,7 +176,7 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
                             addHttpMetric(topic, StatusCodes.BadRequest, "/v2/metadata", startTime, method.value, error=Some(e.getMessage))
                             complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
                           case _ =>
-                            addHttpMetric(topic, StatusCodes.InternalServerError, "/v2/metadata", startTime, method.value)
+                            addHttpMetric(topic, StatusCodes.InternalServerError, "/v2/metadata", startTime, method.value, error=Some(exception.getMessage))
                             complete(StatusCodes.InternalServerError, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
                         }
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -2,7 +2,6 @@ package hydra.kafka.endpoints
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSelection
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
@@ -34,6 +33,7 @@ import akka.http.scaladsl.server.Directives.onComplete
 import akka.http.scaladsl.server.directives.Credentials
 import cats.data.NonEmptyList
 import hydra.avro.registry.SchemaRegistry
+import hydra.avro.registry.SchemaRegistry.IncompatibleSchemaException
 import hydra.kafka.programs.CreateTopicProgram
 import org.apache.avro.{Schema, SchemaParseException}
 import spray.json.DeserializationException
@@ -171,9 +171,15 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
                         Futurable[F].unsafeToFuture(createTopicProgram
                           .createTopicFromMetadataOnly(t, req))
                       ) {
-                        case Failure(exception) =>
-                          addHttpMetric(topic, StatusCodes.BadRequest, "/v2/metadata", startTime, method.value)
-                          complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
+                        case Failure(exception) => exception match {
+                          case e:IncompatibleSchemaException =>
+                            addHttpMetric(topic, StatusCodes.BadRequest, "/v2/metadata", startTime, method.value, error=Some(e.getMessage))
+                            complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
+                          case _ =>
+                            addHttpMetric(topic, StatusCodes.InternalServerError, "/v2/metadata", startTime, method.value)
+                            complete(StatusCodes.InternalServerError, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
+                        }
+
                         case Success(value) =>
                           addHttpMetric(topic, StatusCodes.OK, "/v2/metadata", startTime, method.value)
                           complete(StatusCodes.OK)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -172,7 +172,7 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
                           .createTopicFromMetadataOnly(t, req))
                       ) {
                         case Failure(exception) =>
-                          addHttpMetric(topic, StatusCodes.InternalServerError, "/v2/metadata", startTime, method.value)
+                          addHttpMetric(topic, StatusCodes.BadRequest, "/v2/metadata", startTime, method.value)
                           complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
                         case Success(value) =>
                           addHttpMetric(topic, StatusCodes.OK, "/v2/metadata", startTime, method.value)

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -138,7 +138,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
               val valueFields = schemas.value.getFields.asScala.toList
               val keyNullErrors = keyFields.flatMap(field => field.schema().getType match {
                 case Schema.Type.UNION=> {
-                  if (field.schema.getTypes.asScala.toList.filter(_ isNullable).length > 0)
+                  if (field.schema.getTypes.asScala.toList.exists(_.isNullable))
                     Some(NullableField(field.name(), field.schema()))
                   else None
                 }


### PR DESCRIPTION
The point of this PR is to validate the creation of topics in the same way, whether users are using our standard `v2/topics/... `endpoint, or they create the topic externally and would like to add the topic metadata via` v2/metadata/...`

Changes that were made:
-I created a public `createTopicFromMetadataOnly` def (which calls `validateKeyAndValueSchemas` and `publishMetadata`) which is called by the `v2/metadata/...` endpoint
-I privatized the` publishMetadata `def
-I moved the check that ensures the key schema has `< 0` fields into `validateKeyAndValueSchemas`
-In the `validateKeyAndValueSchemas`, I added a check which ensures key and value schemas are records (this was already happening with moving the check that ensures the key schema has `< 0` fields, but the error message wasn't directing them to the appropriate change)
-I added E2E tests in `Metadata Only `and `Metadata Only Failure` which check that the key and value schemas are record types, in any case