### PR TITLE
Made schemas endpoint use streamsManagerActor instead of going to kafka and updated tests to show that

### DIFF
--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -17,14 +17,6 @@ hydra_test {
           string.consumer {
             value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
           }
-          avro.producer {
-            value.serializer = "io.confluent.kafka.serializers.KafkaAvroSerializer"
-            schema.registry.url = ${hydra_kafka.schema.registry.url}
-          }
-          avro.consumer {
-            value.deserializer = "io.confluent.kafka.serializers.KafkaAvroDeserializer"
-            schema.registry.url = ${hydra_kafka.schema.registry.url}
-          }
           json.producer {
             value.serializer = org.apache.kafka.common.serialization.StringSerializer
           }

--- a/ingest/src/test/resources/reference.conf
+++ b/ingest/src/test/resources/reference.conf
@@ -7,6 +7,36 @@ hydra_test {
     producer.bootstrap.servers = "localhost:6001"
     admin.bootstrap.servers = "localhost:6001"
     consumer.zookeeper.connect = "localhost:6000"
+    consumer.key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+    consumer.value.deserializer = io.confluent.kafka.serializers.KafkaAvroDeserializer
+
+    clients {
+          string.producer {
+            value.serializer = org.apache.kafka.common.serialization.StringSerializer
+          }
+          string.consumer {
+            value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+          }
+          avro.producer {
+            value.serializer = "io.confluent.kafka.serializers.KafkaAvroSerializer"
+            schema.registry.url = ${hydra_kafka.schema.registry.url}
+          }
+          avro.consumer {
+            value.deserializer = "io.confluent.kafka.serializers.KafkaAvroDeserializer"
+            schema.registry.url = ${hydra_kafka.schema.registry.url}
+          }
+          json.producer {
+            value.serializer = org.apache.kafka.common.serialization.StringSerializer
+          }
+          json.consumer {
+            value.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+          }
+          tester.producer {
+            key.serializer = "org.apache.kafka.common.serialization.StringSerializer"
+            value.serializer = "org.apache.kafka.common.serialization.StringSerializer"
+            metadata.fetch.timeout.ms = 1000
+          }
+        }
   }
   schema.registry.url = "mock"
 
@@ -28,6 +58,55 @@ hydra_test {
         consumer_proxy.path = "/user/kafka_consumer_proxy_test"
       }
     }
+
+    bootstrap-config {
+        eos-draining-check-interval = 30ms
+        connection-checker {
+
+          #Flag to turn on connection checker
+          enable = false
+
+          # Amount of attempts to be performed after a first connection failure occurs
+          # Required, non-negative integer
+          max-retries = 3
+
+          # Interval for the connection check. Used as the base for exponential retry.
+          check-interval = 15s
+
+          # Check interval multiplier for backoff interval
+          # Required, positive number
+          backoff-factor = 2.0
+        }
+        partition-handler-warning = 5s
+        partitions = 1
+        replication-factor = 1
+        min-insync-replicas = 1
+        metadata-topic-name = "_hydra.metadata.topic"
+        timeout = 3000
+        failure-retry-millis = 3000
+
+        poll-interval = 50ms
+        poll-timeout = 50ms
+        stop-timeout = 30s
+        close-timeout = 20s
+        commit-timeout = 15s
+        wakeup-timeout = 10s
+        commit-time-warning = 20s
+        wakeup-debug = true
+        commit-refresh-interval = infinite
+        max-wakeups = 2
+        use-dispatcher = "akka.kafka.default-dispatcher"
+        wait-close-partition = 500ms
+        position-timeout = 5s
+        offset-for-times-timeout = 5s
+        metadata-request-timeout = 5s
+
+        kafka-clients {
+          enable.auto.commit = false
+          key.deserializer = org.apache.kafka.common.serialization.StringDeserializer
+          value.deserializer = io.confluent.kafka.serializers.KafkaAvroDeserializer
+        }
+      }
 }
 
 akka {


### PR DESCRIPTION
Updated SchemasEndpoint so it takes in a streamsManagerActor actorRef and uses that to get the list of topics we should fetch schemas for. This should make it so we only attempt to fetch schemas for topics that we have metadata for. We can have high confidence that those have a schema registered in SchemaReg.

Had to copy some of the configs from another test config file over to this test config file in order for the test to build.