### PR TITLE
Unifying StreamsManagerActors

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/BootstrapEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/BootstrapEndpoint.scala
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class BootstrapEndpoint(override val system:ActorSystem) extends RouteSupport
+class BootstrapEndpoint(override val system:ActorSystem, override val streamsManagerActor: ActorRef) extends RouteSupport
   with LoggingAdapter
   with TopicMetadataAdapter
   with HydraDirectives
@@ -44,6 +44,8 @@ class BootstrapEndpoint(override val system:ActorSystem) extends RouteSupport
   with BootstrapEndpointActors {
 
   private implicit val timeout = Timeout(10.seconds)
+
+
 
   override val route: Route = cors(settings) {
     extractMethod { method =>

--- a/ingestors/kafka/src/main/scala/hydra/kafka/services/StreamsManagerActor.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/services/StreamsManagerActor.scala
@@ -183,12 +183,7 @@ object StreamsManagerActor {
       bootstrapKafkaConfig: Config,
       bootstrapServers: String,
       schemaRegistryClient: SchemaRegistryClient
-  ) = {
-    Props(
-      classOf[StreamsManagerActor],
-      bootstrapKafkaConfig,
-      bootstrapServers,
-      schemaRegistryClient
-    )
+  ): Props = {
+    Props(new StreamsManagerActor(bootstrapKafkaConfig, bootstrapServers, schemaRegistryClient))
   }
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/services/TopicBootstrapActor.scala
@@ -51,7 +51,7 @@ import scala.util._
 class TopicBootstrapActor(
     schemaRegistryActor: ActorRef,
     kafkaIngestor: ActorSelection,
-    streamsManagerProps: Props,
+    streamsManagerActor: ActorRef,
     bootstrapConfig: Option[Config] = None
 ) extends Actor
     with ActorLogging
@@ -85,8 +85,6 @@ class TopicBootstrapActor(
   private val failureRetryInterval = bootstrapKafkaConfig
     .getIntOpt("failure-retry-millis")
     .getOrElse(2000)
-
-  private val streamsManagerActor = context.actorOf(streamsManagerProps)
 
   override def preStart(): Unit = {
     pipe(registerSchema(schema)) to self
@@ -308,16 +306,10 @@ object TopicBootstrapActor {
   def props(
       schemaRegistryActor: ActorRef,
       kafkaIngestor: ActorSelection,
-      streamsManagerProps: Props,
+      streamsManagerActor: ActorRef,
       config: Option[Config] = None
   ): Props =
-    Props(
-      classOf[TopicBootstrapActor],
-      schemaRegistryActor,
-      kafkaIngestor,
-      streamsManagerProps,
-      config
-    )
+    Props(new TopicBootstrapActor(schemaRegistryActor, kafkaIngestor, streamsManagerActor, config))
 
   sealed trait TopicBootstrapMessage
 

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointSpec.scala
@@ -1,6 +1,6 @@
 package hydra.kafka.endpoints
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.http.javadsl.server.MalformedRequestContentRejection
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.RequestEntityExpectedRejection
@@ -13,6 +13,8 @@ import hydra.core.protocol.{Ingest, IngestorCompleted, IngestorError}
 import hydra.kafka.marshallers.HydraKafkaJsonSupport
 import hydra.kafka.model.TopicMetadata
 import hydra.kafka.producer.AvroRecord
+import hydra.kafka.services.StreamsManagerActor
+import hydra.kafka.util.KafkaUtils
 import io.confluent.kafka.serializers.KafkaAvroSerializer
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.avro.Schema
@@ -73,7 +75,18 @@ class BootstrapEndpointSpec
   val ingestorRegistry =
     system.actorOf(Props(new IngestorRegistry), "ingestor_registry")
 
-  private val bootstrapRoute = new BootstrapEndpoint(system).route
+  private[kafka] val bootstrapKafkaConfig =
+    applicationConfig.getConfig("bootstrap-config")
+
+  val streamsManagerProps = StreamsManagerActor.props(
+    bootstrapKafkaConfig,
+    KafkaUtils.BootstrapServers,
+    ConfluentSchemaRegistry.forConfig(applicationConfig).registryClient
+  )
+  val streamsManagerActor: ActorRef = system.actorOf(streamsManagerProps, "streamsManagerActor")
+
+
+  private val bootstrapRoute = new BootstrapEndpoint(system, streamsManagerActor).route
 
   implicit val f = jsonFormat11(TopicMetadata)
 
@@ -367,7 +380,7 @@ class BootstrapEndpointSpec
       )
 
       val bootstrapRouteWithOverridenStreamManager =
-        (new BootstrapEndpoint(system) with BootstrapEndpointTestActors).route
+        (new BootstrapEndpoint(system, streamsManagerActor) with BootstrapEndpointTestActors).route
       Post("/streams", testEntity) ~> bootstrapRouteWithOverridenStreamManager ~> check {
         status shouldBe StatusCodes.OK
       }
@@ -401,7 +414,7 @@ class BootstrapEndpointSpec
       )
 
       val bootstrapRouteWithOverridenStreamManager =
-        (new BootstrapEndpoint(system) with BootstrapEndpointTestActors).route
+        (new BootstrapEndpoint(system, streamsManagerActor) with BootstrapEndpointTestActors).route
       Get("/streams/exp.test-existing.v1.SubjectPreexisted") ~> bootstrapRouteWithOverridenStreamManager ~> check {
         val originalTopicData = responseAs[Seq[TopicMetadata]]
         val originalTopicCreationDate = originalTopicData.head.createdDate

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointTestActors.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointTestActors.scala
@@ -59,17 +59,11 @@ trait BootstrapEndpointTestActors extends BootstrapEndpointActors {
     }
   }
 
-  private[kafka] val streamsManagerPropsTest = StreamsActorTest.props(
-    bootstrapKafkaConfig,
-    KafkaUtils.BootstrapServers,
-    ConfluentSchemaRegistry.forConfig(applicationConfig).registryClient
-  )
-
   override val bootstrapActor: ActorRef = system.actorOf(
     TopicBootstrapActor.props(
       schemaRegistryActor,
       kafkaIngestor,
-      streamsManagerPropsTest,
+      streamsManagerActor,
       Some(bootstrapKafkaConfig)
     )
   )

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointTestActors.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointTestActors.scala
@@ -63,7 +63,8 @@ trait BootstrapEndpointTestActors extends BootstrapEndpointActors {
     TopicBootstrapActor.props(
       schemaRegistryActor,
       kafkaIngestor,
-      streamsManagerActor,
+      system.actorOf(StreamsActorTest.props(bootstrapKafkaConfig, KafkaUtils.BootstrapServers,
+        ConfluentSchemaRegistry.forConfig(applicationConfig).registryClient)),
       Some(bootstrapKafkaConfig)
     )
   )

--- a/ingestors/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/services/TopicBootstrapActorSpec.scala
@@ -162,7 +162,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test1"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -218,7 +218,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test2"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -268,7 +268,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test3"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -317,7 +317,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test4"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -366,7 +366,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test5"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -447,7 +447,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test6"),
-        Props(new MockStreamsManagerActor()),
+        system.actorOf(Props(new MockStreamsManagerActor())),
         Some(testConfig)
       )
     )
@@ -514,7 +514,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test7"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -563,7 +563,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("kafka_ingestor_test-get-stream"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -586,7 +586,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("kafka_ingestor_test-get-stream-subject"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -639,7 +639,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test8"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
     probe.expectMsgType[RegisterSchemaRequest]
@@ -700,7 +700,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test12"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 
@@ -754,7 +754,7 @@ class TopicBootstrapActorSpec
       TopicBootstrapActor.props(
         schemaRegistryActor,
         system.actorSelection("/user/kafka_ingestor_test13"),
-        Props(new MockStreamsManagerActor())
+        system.actorOf(Props(new MockStreamsManagerActor()))
       )
     )
 


### PR DESCRIPTION
This is an attempt to fix the issues with the /streams endpoint returning an empty list.

The idea is that we were creating multiple streamsManagerActors when we assumed the same one was being reused. Creating multiple actors would mean multiple kafka consumers would be created and since there is only one partition in the TopicMetadata only one of the consumers would ever see any data. 

We switched to pass in the same actor to both places it is needed. 