### PR TITLE
changed acks to one

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/util/ConsumerGroupsOffsetConsumer.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/util/ConsumerGroupsOffsetConsumer.scala
@@ -94,9 +94,10 @@ object ConsumerGroupsOffsetConsumer {
                                                              valueSerializer: Serializer[F, GenericRecord]
                                                            ): fs2.Stream[F, ProducerRecords[Array[Byte], Array[Byte], Unit]] = {
     ((cr.record.key, cr.record.value) match {
-      case (Some(OffsetKey(_, k)), offsetMaybe) =>
-        val topicMaybe: Option[String] = Option(k.topicPartition.topic())
-        val consumerGroupMaybe: Option[String] = Option(k.group)
+      case (Some(OffsetKey(_, groupTopicPartition)), offsetMaybe) =>
+        val maybeK = Option(groupTopicPartition)
+        val topicMaybe: Option[String] = maybeK.flatMap(k => Option(k.topicPartition).flatMap(tp => Option(tp.topic())))
+        val consumerGroupMaybe: Option[String] = maybeK.flatMap(k => Option(k.group))
         val consumerKeyMaybe: Option[TopicConsumerKey] = consumerGroupMaybe.flatMap(cg => topicMaybe.map(t => TopicConsumerKey(t, cg)))
         val consumerValue = offsetMaybe.map(o => Instant.ofEpochMilli(o.commitTimestamp)).map(TopicConsumerValue.apply)
 
@@ -151,7 +152,7 @@ object ConsumerGroupsOffsetConsumer {
     val producerSettings = ProducerSettings[F, Array[Byte], Array[Byte]]
       .withBootstrapServers(bootstrapServers)
       .withRetries(0)
-      .withAcks(Acks.All)
+      .withAcks(Acks.One)
     val consumer = consumerStream(settings)
     val keySerializer = getSerializer[F, GenericRecord](s)(isKey = true)
     val valueSerializer = getSerializer[F, GenericRecord](s)(isKey = false)


### PR DESCRIPTION
@bretrbs and I stepped through all the suspicions of where the stream might be dying, but concluded that rather than the consumer dying, the producer may be stuck. We came to this conclusion because consumer code catches all errors and logs appropriately. Basically, the producer was waiting for acknowledgement from all in-sync replicas when producing records. Now, it will only wait for acknowledgement from the leader node when producing records. Since it's difficult to replicate this issue, we will just push this and see if it fixes the issue. I tested the consumer endpoint and it seems to be working as expected. Bret also changed some things in the consumer code for fun.