### PR TITLE
Fix/valid namespace

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
@@ -250,7 +250,7 @@ sealed trait TopicMetadataV2Parser
 
       if(isNamespaceInvalid(schema)) {
         throw DeserializationException(InvalidSchema(json, isKey,
-          Some(InvalidNamespace(s"Invalid character "))).errorMessage)
+          Some(InvalidNamespace(s"""Invalid character in Namespace. Namespace must conform to the regex ^[A-Za-z0-9_\\.]+"""))).errorMessage)
       } else {
         schema
       }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
@@ -233,7 +233,7 @@ sealed trait TopicMetadataV2Parser
       val t = schema.getType
       t match {
         case Schema.Type.RECORD =>
-          val currentNamespace = Option(schema.getNamespace).exists(f => f.contains("-"))
+          val currentNamespace = Option(schema.getNamespace).exists(f => f.matches("""^[A-Za-z0-9_\\.]+"""))
           val allRecords = schema.getFields.asScala.toList.exists(f => isNamespaceInvalid(f.schema()))
           currentNamespace || allRecords
         case _ => false
@@ -250,7 +250,7 @@ sealed trait TopicMetadataV2Parser
 
       if(isNamespaceInvalid(schema)) {
         throw DeserializationException(InvalidSchema(json, isKey,
-          Some(InvalidNamespace("Invalid character dash (-)"))).errorMessage)
+          Some(InvalidNamespace(s"Invalid character "))).errorMessage)
       } else {
         schema
       }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/serializers/TopicMetadataV2Parser.scala
@@ -233,7 +233,7 @@ sealed trait TopicMetadataV2Parser
       val t = schema.getType
       t match {
         case Schema.Type.RECORD =>
-          val currentNamespace = Option(schema.getNamespace).exists(f => f.matches("""^[A-Za-z0-9_\\.]+"""))
+          val currentNamespace = Option(schema.getNamespace).exists(f => !f.matches("""^[A-Za-z0-9_\\.]+"""))
           val allRecords = schema.getFields.asScala.toList.exists(f => isNamespaceInvalid(f.schema()))
           currentNamespace || allRecords
         case _ => false

--- a/ingestors/kafka/src/test/scala/hydra/kafka/serializers/TopicMetadataV2ParserSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/serializers/TopicMetadataV2ParserSpec.scala
@@ -238,7 +238,7 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       the[DeserializationException] thrownBy {
         new SchemaFormat(isKey = false).read(invalidAvroSchemaNamespace).getName
       } should have message InvalidSchema(invalidAvroSchemaNamespace, isKey = false).errorMessage
-        .concat("\nError: One or more of the Namespaces provided are invalid due to: Invalid character dash (-)\n")
+        .concat("\nError: One or more of the Namespaces provided are invalid due to: Invalid character in Namespace. Namespace must conform to the regex ^[A-Za-z0-9_\\.]+\n")
     }
 
     "throw an error with '-' in the name of a schema" in {
@@ -252,7 +252,7 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       the[DeserializationException] thrownBy {
         new SchemaFormat(isKey = false).read(invalidAvroSchemaNestedNamespace).getName
       } should have message InvalidSchema(invalidAvroSchemaNestedNamespace, isKey = false).errorMessage
-        .concat("\nError: One or more of the Namespaces provided are invalid due to: Invalid character dash (-)\n")
+        .concat("\nError: One or more of the Namespaces provided are invalid due to: Invalid character in Namespace. Namespace must conform to the regex ^[A-Za-z0-9_\\.]+\n")
     }
 
     "throw an error with '-' in the name of a nested schema" in {


### PR DESCRIPTION
Previously we were just checking to ensure that namespaces did not contain dashes. We now are checking to ensure that there are only valid characters with the given regex.