### PR TITLE
Bypass event record type check

### DIFF
--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -255,13 +255,12 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
         .stringType()
         .noDefault()
         .endRecord().getFields.asScala.toList
-      val keyFields = schemas.key.getFields.asScala.toList
       val valueFields = schemas.value.getFields.asScala.toList
       val validationErrors = for {
         kv <- validateSchemaEvolutions(schemas, subject)
       } yield {
         val valueNullableFieldCheckedForDefault = checkForDefaultNullableValueFields(valueFields)
-        val keyFieldsCheckedUnsupportedLogicalType = checkForUnsupportedLogicalType(keyFields)
+        val keyFieldsCheckedUnsupportedLogicalType = checkForUnsupportedLogicalType(concoctedKeyFields)
         val valueFieldsCheckedUnsupportedLogicalType =  checkForUnsupportedLogicalType(valueFields)
         List[Option[RuntimeException]](
           checkForMismatches(concoctedKeyFields, valueFields),
@@ -288,8 +287,8 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
     } yield {
       val keyFieldsCheckedForNull = if(isEventStream) none else checkForNullableKeyFields(keyFields)
       val valueNullableFieldCheckedForDefault = checkForDefaultNullableValueFields(valueFields)
-      val keyFieldsCheckedUnsupportedLogicalType = if(isEventStream) checkForUnsupportedLogicalType(keyFields) else None
-      val valueFieldsCheckedUnsupportedLogicalType = if(isEventStream) checkForUnsupportedLogicalType(valueFields) else None
+      val keyFieldsCheckedUnsupportedLogicalType = checkForUnsupportedLogicalType(keyFields)
+      val valueFieldsCheckedUnsupportedLogicalType = checkForUnsupportedLogicalType(valueFields)
       List[Option[RuntimeException]](
         checkForMismatches(keyFields, valueFields),
         keyFieldIsEmpty,

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -242,7 +242,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
   private def validateKeyAndValueSchemas(request: TopicMetadataV2Request, subject: Subject): Resource[F, Unit] = {
     val schemas = request.schemas
     val isEventStream = request.streamType == StreamTypeV2.Event
-    val allValidationErrors: F[Unit] = (schemas.key.getType, schemas.value.getType) match {
+    val completedValidations: F[Unit] = (schemas.key.getType, schemas.value.getType) match {
       case (Schema.Type.RECORD, Schema.Type.RECORD) =>
         val keyFields = schemas.key.getFields.asScala.toList
         val valueFields = schemas.value.getFields.asScala.toList
@@ -291,7 +291,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
         } else Bracket[F, Throwable].raiseError(KeyAndValueNotRecordType)
       case _ => Bracket[F, Throwable].raiseError(KeyAndValueNotRecordType)
     }
-    Resource.liftF(allValidationErrors)
+    Resource.liftF(completedValidations)
   }
 
   def createTopicFromMetadataOnly(

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -291,7 +291,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
         } else Bracket[F, Throwable].raiseError(KeyAndValueNotRecordType)
       case _ => Bracket[F, Throwable].raiseError(KeyAndValueNotRecordType)
     }
-    Resource.liftF(consolidatedValidationErrors)
+    Resource.liftF(allValidationErrors)
   }
 
   def createTopicFromMetadataOnly(

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -267,7 +267,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       case (Schema.Type.STRING, Schema.Type.RECORD) =>
         if (isEventStream) {
           val concoctedKeyFields = SchemaBuilder
-            .record("fakeName")
+            .record("uselessRecord") //This is a useless record whose only purpose is to transform the string key into a list of fields.
             .fields()
             .name(schemas.key.getName)
             .`type`()


### PR DESCRIPTION
I changed verification logic for keys if streamType is 'Event'. I also checked with Theo that his only use cases are `record` and `string` types at the highest level of the key schema and decided to explicitly case match for these scenarios to avoid any ambiguity.