### PR TITLE
ADAPT-825: reworked topic's schema validation.

### DIFF
--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -11,7 +11,7 @@ import hydra.kafka.algebras.KafkaClientAlgebra.{ConsumerGroup, Offset, Partition
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
 import hydra.kafka.model.{ContactMethod, TopicMetadataV2, TopicMetadataV2Key}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
-import hydra.kafka.programs.CreateTopicProgram
+import hydra.kafka.programs.{CreateTopicProgram, KeyAndValueSchemaV2Validator}
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.apache.avro.generic.GenericRecord
@@ -56,7 +56,8 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers {
         kafkaClient,
         retry,
         metadataSubjectV2,
-        metadata
+        metadata,
+        KeyAndValueSchemaV2Validator.make(schemaRegistry)
       )
       boot <- Bootstrap.make[IO](c, metadataConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig, kafkaAdmin, tagsTopicConfig)
       _ <- boot.bootstrapAll

--- a/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/endpoints/TopicMetadataEndpoint.scala
@@ -34,7 +34,7 @@ import akka.http.scaladsl.server.directives.Credentials
 import cats.data.NonEmptyList
 import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.IncompatibleSchemaException
-import hydra.kafka.programs.CreateTopicProgram
+import hydra.kafka.programs.{CreateTopicProgram, ValidationError}
 import org.apache.avro.{Schema, SchemaParseException}
 import spray.json.DeserializationException
 
@@ -172,7 +172,7 @@ class TopicMetadataEndpoint[F[_]: Futurable](consumerProxy:ActorSelection,
                           .createTopicFromMetadataOnly(t, req))
                       ) {
                         case Failure(exception) => exception match {
-                          case e:IncompatibleSchemaException =>
+                          case e @ (_:IncompatibleSchemaException | _:ValidationError) =>
                             addHttpMetric(topic, StatusCodes.BadRequest, "/v2/metadata", startTime, method.value, error=Some(e.getMessage))
                             complete(StatusCodes.BadRequest, s"Unable to create Metadata for topic $topic : ${exception.getMessage}")
                           case _ =>

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -5,7 +5,7 @@ import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.SchemaVersion
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
-import hydra.kafka.model.{TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
+import hydra.kafka.model.{StreamTypeV2, TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
 import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.Logger
 import org.apache.avro.Schema

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/CreateTopicProgram.scala
@@ -1,19 +1,17 @@
 package hydra.kafka.programs
 import java.time.Instant
-import cats.effect.{Bracket, ExitCase, Resource, Sync}
+import cats.effect.{Bracket, ExitCase, Resource}
 import hydra.avro.registry.SchemaRegistry
-import hydra.avro.registry.SchemaRegistry.{IllegalLogicalTypeChange, IllegalLogicalTypeChangeErrors, IncompatibleSchemaException, SchemaVersion}
+import hydra.avro.registry.SchemaRegistry.SchemaVersion
 import hydra.kafka.algebras.{KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
-import hydra.kafka.model.{Schemas, StreamTypeV2, TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
-import hydra.kafka.programs.CreateTopicProgram.{IncompatibleKeyAndValueFieldNames, KeyAndValueMismatch, KeyHasNullableFields, NullableField, NullableFieldWithoutDefaultValue, NullableFieldsNeedDefaultValue, ValidationErrors}
+import hydra.kafka.model.{TopicMetadataV2, TopicMetadataV2Key, TopicMetadataV2Request}
 import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.Logger
-import org.apache.avro.{LogicalType, Schema}
+import org.apache.avro.Schema
 import retry.syntax.all._
 import retry.{RetryDetails, RetryPolicy, _}
 import cats.implicits._
-import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 
 final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
                                                                                schemaRegistry: SchemaRegistry[F],
@@ -21,7 +19,8 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
                                                                                kafkaClient: KafkaClientAlgebra[F],
                                                                                retryPolicy: RetryPolicy[F],
                                                                                v2MetadataTopicName: Subject,
-                                                                               metadataAlgebra: MetadataAlgebra[F]
+                                                                               metadataAlgebra: MetadataAlgebra[F],
+                                                                               keyAndValueSchemaV2Validator: KeyAndValueSchemaV2Validator[F]
                                                                              ) {
 
   private def onFailure(resourceTried: String): (Throwable, RetryDetails) => F[Unit] = {
@@ -123,155 +122,11 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
     } yield ()
   }
 
-  private def validateKeySchemaEvolution(schemas: Schemas, subject: Subject): F[Option[IllegalLogicalTypeChangeErrors]] = {
+  def createTopicFromMetadataOnly(topicName: Subject, createTopicRequest: TopicMetadataV2Request): F[Unit] =
     for {
-      sch <- schemaRegistry.getLatestSchemaBySubject(subject + "-key")
-    } yield {
-      sch match {
-        case Some(keySchema) =>
-          val keyTransformationErrors = checkForIllegalLogicalTypeEvolutions(keySchema, schemas.key, keySchema.getName)
-          if (keyTransformationErrors.nonEmpty) {
-            IllegalLogicalTypeChangeErrors(keyTransformationErrors).some
-          } else None
-        case None => None
-      }
-    }
-  }
-
-  private def validateValueSchemaEvolution(schemas: Schemas, subject: Subject): F[Option[IllegalLogicalTypeChangeErrors]] = {
-    for {
-      sch <- schemaRegistry.getLatestSchemaBySubject(subject + "-value")
-    } yield {
-      sch match {
-        case Some(valueSchema) =>
-          val valueTransformationErrors = checkForIllegalLogicalTypeEvolutions(valueSchema, schemas.value, valueSchema.getName)
-          if (valueTransformationErrors.nonEmpty){
-            IllegalLogicalTypeChangeErrors(valueTransformationErrors).some
-          } else None
-        case None => None
-      }
-    }
-  }
-
-  private def checkForIllegalLogicalTypeEvolutions(existingSchema: Schema, newSchema: Schema, name: String) : List[IllegalLogicalTypeChange] = existingSchema.getType match {
-    case Schema.Type.RECORD =>
-      newSchema.getType match {
-        case Schema.Type.RECORD =>
-          existingSchema.getFields.asScala.toList.flatMap{ existingField =>
-            newSchema.getFields.asScala.toList.filter(f => f.name() == existingField.name()).flatMap { newField =>
-              checkForIllegalLogicalTypeEvolutions(existingField.schema(), newField.schema(), existingField.name())
-            }
-          }
-        case _ => List()
-      }
-    case Schema.Type.ARRAY =>
-      newSchema.getType match {
-        case Schema.Type.ARRAY =>
-          checkForIllegalLogicalTypeEvolutions(existingSchema.getElementType, newSchema.getElementType, existingSchema.getName)
-        case _ => List()
-      }
-    case Schema.Type.MAP =>
-      newSchema.getType match {
-        case Schema.Type.MAP => {
-          checkForIllegalLogicalTypeEvolutions(existingSchema.getValueType, newSchema.getValueType, existingSchema.getName)
-        }
-        case _ => List()
-      }
-    case Schema.Type.ENUM | Schema.Type.FIXED => {
-      List()
-    }
-    case _ if existingSchema.isUnion => {
-      if(newSchema.isUnion) existingSchema.getTypes.asScala.toList zip newSchema.getTypes.asScala.toList flatMap { t =>
-        checkForIllegalLogicalTypeEvolutions(t._1, t._2, existingSchema.getName)
-      } else List()
-    }
-    case _ =>
-      if (existingSchema.getLogicalType != newSchema.getLogicalType)
-        List(IllegalLogicalTypeChange(existingSchema.getLogicalType, newSchema.getLogicalType, name))
-      else List()
-  }
-
-  private def checkForNullableKeyFields(keyFields: List[Schema.Field]): Option[KeyHasNullableFields] = {
-    val nullableKeyFields = keyFields.flatMap(field => field.schema().getType match {
-      case Schema.Type.UNION =>
-        if (field.schema.getTypes.asScala.toList.exists(_.isNullable)) Some(NullableField(field.name(), field.schema())) else None
-      case Schema.Type.NULL => Some(NullableField(field.name(), field.schema()))
-      case _ => None
-    })
-    if (nullableKeyFields.nonEmpty) {
-      KeyHasNullableFields(nullableKeyFields).some
-    } else None
-  }
-
-  private def checkForDefaultNullableValueFields(valueFields: List[Schema.Field]): Option[NullableFieldsNeedDefaultValue] = {
-    val errors = valueFields.flatMap { field => field.schema().getType match {
-        case Schema.Type.UNION => if (field.schema().getTypes.asScala.toList.exists(_.isNullable) && Option(field.defaultVal()).isEmpty)
-                                    Some(NullableFieldWithoutDefaultValue(field.name(), field.schema()))
-                                  else None
-        case _ => None
-      }
-    }
-
-    if (errors.nonEmpty) {
-      NullableFieldsNeedDefaultValue(errors).some
-    } else  None
-  }
-
-  private def checkForMismatches(keyFields: List[Schema.Field], valueFields: List[Schema.Field]): Option[IncompatibleKeyAndValueFieldNames] = {
-    val mismatches = keyFields.flatMap { k =>
-      valueFields.flatMap { v =>
-        if (k.name() == v.name() && !k.schema().equals(v.schema())) {
-          Some(KeyAndValueMismatch(k.name(), k.schema(), v.schema()))
-        } else {
-          None
-        }
-      }
-    }
-    if (mismatches.nonEmpty) {
-      IncompatibleKeyAndValueFieldNames(mismatches).some
-    } else None
-  }
-
-  private def validateKeyAndValueSchemas(request: TopicMetadataV2Request, subject: Subject): Resource[F, Unit] = {
-    val schemas = request.schemas
-    val validate: F[Unit] =
-      (schemas.key.getType, schemas.value.getType) match {
-        case (Schema.Type.RECORD, Schema.Type.RECORD) =>
-          val keyFields = schemas.key.getFields.asScala.toList
-          val valueFields = schemas.value.getFields.asScala.toList
-          val keyFieldIsEmpty: Option[IncompatibleSchemaException] = if (keyFields.isEmpty) {
-            IncompatibleSchemaException("Must include Fields in Key").some
-          } else None
-          val validationErrorsF: F[List[RuntimeException]] = for {
-            k <- validateKeySchemaEvolution(schemas, subject)
-            v <- validateValueSchemaEvolution(schemas, subject)
-          } yield {
-            val keyFieldsCheckedForNullIfNecessary = if(request.streamType != StreamTypeV2.Event) checkForNullableKeyFields(keyFields) else None
-            val valueNullableFieldCheckedForDefault = if(request.streamType != StreamTypeV2.Event) checkForDefaultNullableValueFields(valueFields) else None
-            List[Option[RuntimeException]](keyFieldIsEmpty,
-              checkForMismatches(keyFields, valueFields),
-              keyFieldsCheckedForNullIfNecessary,
-              valueNullableFieldCheckedForDefault,
-              k,
-              v).flatten
-          }
-          validationErrorsF.flatMap { validationErrors =>
-            if (validationErrors.nonEmpty) Bracket[F, Throwable].raiseError(ValidationErrors(validationErrors))
-            else Bracket[F, Throwable].pure(())
-          }
-        case _ => Bracket[F, Throwable].raiseError(IncompatibleSchemaException("Your key and value schemas must each be of type record. If you are adding metadata for a topic you created externally, you will need to register new key and value schemas"))
-      }
-    Resource.liftF(validate)
-  }
-
-  def createTopicFromMetadataOnly(
-                                   topicName: Subject,
-                                   createTopicRequest: TopicMetadataV2Request): F[Unit] = {
-    (for {
-      _ <- validateKeyAndValueSchemas(createTopicRequest, topicName)
-      _ <- Resource.liftF(publishMetadata(topicName, createTopicRequest))
-    } yield()).use(_ => Bracket[F, Throwable].unit)
-  }
+      _ <- keyAndValueSchemaV2Validator.validate(createTopicRequest, topicName)
+      _ <- publishMetadata(topicName, createTopicRequest)
+    } yield ()
 
   def createTopic(
                    topicName: Subject,
@@ -281,7 +136,7 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
     val td = createTopicRequest.numPartitions.map(numP =>
       defaultTopicDetails.copy(numPartitions = numP.value)).getOrElse(defaultTopicDetails)
     (for {
-      _ <- validateKeyAndValueSchemas(createTopicRequest, topicName)
+      _ <- Resource.liftF(keyAndValueSchemaV2Validator.validate(createTopicRequest, topicName))
       _ <- registerSchemas(
         topicName,
         createTopicRequest.schemas.key,
@@ -291,23 +146,4 @@ final class CreateTopicProgram[F[_]: Bracket[*[_], Throwable]: Sleep: Logger](
       _ <- Resource.liftF(publishMetadata(topicName, createTopicRequest))
     } yield ()).use(_ => Bracket[F, Throwable].unit)
   }
-}
-
-object CreateTopicProgram {
-  final case class KeyAndValueMismatch(fieldName: String, keyFieldSchema: Schema, valueFieldSchema: Schema)
-  final case class NullableField(fieldName: String, keyFieldSchema: Schema)
-  final case class NullableFieldWithoutDefaultValue(fieldName: String, valueFieldSchema: Schema)
-  final case class KeyHasNullableFields(errors: List[NullableField]) extends
-    RuntimeException(
-      (List("Fields within the key object cannot be nullable:", "Field Name\tKey Schema") ++ errors.map(e => s"${e.fieldName}\t${e.keyFieldSchema.toString}")).mkString("\n")
-    )
-  final case class NullableFieldsNeedDefaultValue(error: List[NullableFieldWithoutDefaultValue]) extends RuntimeException(
-    (List("Nullable fields should have default value:", "Field Name\tValue Schema") ++ error.map(e => s"${e.fieldName}\t${e.valueFieldSchema.toString}")).mkString("\n")
-  )
-  final case class IncompatibleKeyAndValueFieldNames(errors: List[KeyAndValueMismatch]) extends
-    RuntimeException(
-      (List("Fields with same names in key and value schemas must have same type:", "Field Name\tKey Schema\tValue Schema") ++ errors.map(e => s"${e.fieldName}\t${e.keyFieldSchema.toString}\t${e.valueFieldSchema}")).mkString("\n")
-    )
-  final case class ValidationErrors(listOfRuntimeException: List[RuntimeException]) extends
-    RuntimeException(listOfRuntimeException.map(_.getMessage).mkString("\n"))
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/TopicSchemaError.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/TopicSchemaError.scala
@@ -29,4 +29,8 @@ object TopicSchemaError {
   case class IncompatibleKeyAndValueFieldNamesError(fieldName: String, keyFieldSchema: Schema, valueFieldSchema: Schema) extends TopicSchemaError {
     override val message: String = s"Fields with same names in key and value schemas must have same type: field name = $fieldName, key schema = $keyFieldSchema, value schema = $valueFieldSchema."
   }
+
+  case class UnsupportedLogicalType(unsupportedField: Schema.Field, unsupportedLogicalType: String) extends TopicSchemaError {
+    override val message: String =  s"Field named '${unsupportedField.name()}' has unsupported logical type '$unsupportedLogicalType'"
+  }
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/TopicSchemaError.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/TopicSchemaError.scala
@@ -1,0 +1,32 @@
+package hydra.kafka.programs
+
+import org.apache.avro.Schema
+
+sealed trait TopicSchemaError extends ValidationError
+
+object TopicSchemaError {
+  case object InvalidSchemaTypeError extends TopicSchemaError {
+    override val message: String = "Your key and value schemas must each be of type record. If you are adding metadata for a topic you created externally, you will need to register new key and value schemas"
+  }
+
+  case object KeyIsEmptyError extends TopicSchemaError {
+    override val message: String = "Must include Fields in Key"
+  }
+
+  case class IllegalLogicalTypeChangeError(originalType: String, proposedType: String, fieldName: String) extends TopicSchemaError {
+    override val message: String = s"Changing logical types is not allowed. Field named '$fieldName's logical type cannot be changed from " +
+      s"logicalType of '$originalType' to logicalType of '$proposedType'"
+  }
+
+  case class KeyHasNullableFieldError(fieldName: String, keyFieldSchema: Schema) extends TopicSchemaError {
+    override val message: String = s"Fields within the key object cannot be nullable: field name = $fieldName, key schema = $keyFieldSchema."
+  }
+
+  case class NullableFieldWithoutDefaultValueError(fieldName: String, valueFieldSchema: Schema) extends TopicSchemaError {
+    override val message: String = s"Nullable field should have default value: field name = $fieldName, key schema = $valueFieldSchema."
+  }
+
+  case class IncompatibleKeyAndValueFieldNamesError(fieldName: String, keyFieldSchema: Schema, valueFieldSchema: Schema) extends TopicSchemaError {
+    override val message: String = s"Fields with same names in key and value schemas must have same type: field name = $fieldName, key schema = $keyFieldSchema, value schema = $valueFieldSchema."
+  }
+}

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/ValidationError.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/ValidationError.scala
@@ -1,0 +1,15 @@
+package hydra.kafka.programs
+
+import scala.util.control.NoStackTrace
+
+trait ValidationError extends NoStackTrace {
+  def message: String
+
+  override def getMessage: String = message
+}
+
+object ValidationError {
+  case class ValidationCombinedErrors(errors: List[String]) extends ValidationError {
+    override val message: String = errors.mkString("\n")
+  }
+}

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/Validator.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/Validator.scala
@@ -1,0 +1,28 @@
+package hydra.kafka.programs
+
+import cats.MonadThrow
+import cats.syntax.all._
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import hydra.kafka.programs.ValidationError.ValidationCombinedErrors
+
+trait Validator {
+  import Validator._
+
+  protected def resultOf[F[_]](chain: ValidationChain*)(implicit eff: MonadThrow[F]): F[Unit] =
+    eff.fromEither(chain.toList.sequence.toEither.bimap(errors => merge(errors.toList), _ => ()))
+
+  protected def resultOf[F[_]: MonadThrow](chainF: F[List[ValidationChain]]): F[Unit] =
+    chainF.map(_.sequence.toEither.bimap(errors => merge(errors.toList), _ => ())).rethrow
+
+  protected def validate(test: Boolean, error: => ValidationError): ValidationChain =
+    if (test) valid else Validated.Invalid(NonEmptyChain.one(error))
+
+  private def merge(errors: List[ValidationError]): ValidationError =
+    if (errors.size == 1) errors.head else ValidationCombinedErrors(errors.map(_.message))
+}
+
+object Validator {
+  type ValidationChain = ValidatedNec[ValidationError, Any]
+
+  val valid: ValidationChain = Validated.Valid(())
+}

--- a/ingestors/kafka/src/test/scala/hydra/kafka/IOSuite.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/IOSuite.scala
@@ -1,0 +1,21 @@
+package hydra.kafka
+
+import scala.concurrent.duration._
+import cats.effect.{ContextShift, IO, Resource, Timer}
+import cats.implicits._
+import org.scalatest.{Assertion, AsyncTestSuite}
+import retry.RetryPolicies.{exponentialBackoff, limitRetries}
+import retry.RetryPolicy
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait IOSuite { _: AsyncTestSuite =>
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+
+  implicit val defaultRetryPolicy: RetryPolicy[IO] = limitRetries[IO](5) |+| exponentialBackoff[IO](500.milliseconds)
+
+  implicit def ioToFutureAssertion(io: IO[Assertion]): Future[Assertion] = io.unsafeToFuture()
+
+  implicit def resourceToFutureAssertion(resource: Resource[IO, Assertion]): Future[Assertion] = resource.allocated.unsafeToFuture().map(_._1)
+}

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
@@ -1,20 +1,18 @@
 package hydra.kafka.endpoints
 
 import java.time.Instant
-import akka.http.javadsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, HttpHeader, MediaTypes, StatusCodes}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, MediaTypes, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.data.NonEmptyList
 import cats.effect.{Concurrent, ContextShift, IO, Timer}
 import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
-import hydra.core.marshallers.{History, StreamType}
 import hydra.kafka.algebras.{HydraTag, KafkaAdminAlgebra, KafkaClientAlgebra, MetadataAlgebra, TagsAlgebra}
 import hydra.kafka.model.ContactMethod.{Email, Slack}
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import hydra.kafka.model._
-import hydra.kafka.programs.CreateTopicProgram
+import hydra.kafka.programs.{CreateTopicProgram, KeyAndValueSchemaV2Validator}
 import hydra.kafka.serializers.TopicMetadataV2Parser
 import hydra.kafka.util.KafkaUtils.TopicDetails
 import io.chrisdavenport.log4cats.Logger
@@ -56,7 +54,8 @@ final class BootstrapEndpointV2Spec
         kc,
         retryPolicy,
         Subject.createValidated("dvs.hello-world").get,
-        m
+        m,
+        KeyAndValueSchemaV2Validator.make(s)
       ),
       TopicDetails(1, 1, 1),
       t

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/TopicMetadataEndpointSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/TopicMetadataEndpointSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.ExecutionContext
-import hydra.kafka.programs.CreateTopicProgram
+import hydra.kafka.programs.{CreateTopicProgram, KeyAndValueSchemaV2Validator}
 import org.apache.avro.{Schema, SchemaBuilder}
 import retry.{RetryPolicies, RetryPolicy}
 
@@ -86,7 +86,8 @@ class TopicMetadataEndpointSpec
         kc,
         retryPolicy,
         Subject.createValidated("dvs.hello-world").get,
-        m
+        m,
+        KeyAndValueSchemaV2Validator.make(s)
       )
   }
 

--- a/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/programs/CreateTopicProgramSpec.scala
@@ -1,10 +1,11 @@
 package hydra.kafka.programs
 
+import cats.effect._
+import cats.syntax.all._
 import java.time.Instant
 import cats.data.NonEmptyList
 import cats.effect.concurrent.Ref
-import cats.effect.{Bracket, Concurrent, ContextShift, IO, Resource, Sync, Timer}
-import cats.syntax.all._
+import fs2.kafka.Headers
 import fs2.kafka._
 import hydra.avro.registry.SchemaRegistry
 import hydra.avro.registry.SchemaRegistry.{SchemaId, SchemaVersion}
@@ -22,203 +23,74 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
 import retry.{RetryPolicies, RetryPolicy}
 import eu.timepit.refined._
-
+import hydra.kafka.IOSuite
 import scala.concurrent.ExecutionContext
 import hydra.kafka.model.TopicMetadataV2Request.NumPartitions
-import hydra.kafka.programs.CreateTopicProgram._
+import hydra.kafka.programs.TopicSchemaError._
 import org.apache.kafka.common.TopicPartition
-import org.scalatest.compatible.Assertion
+import org.scalatest.freespec.AsyncFreeSpec
 
-class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
 
-  implicit private def unsafeLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] =
-    Slf4jLogger.getLogger[F]
-  implicit val timer: Timer[IO] = IO.timer(concurrent.ExecutionContext.global)
-  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-  private implicit val concurrentEffect: Concurrent[IO] = IO.ioConcurrentEffect
-  type Record = (GenericRecord, Option[GenericRecord], Option[Headers])
+class CreateTopicProgramSpec extends AsyncFreeSpec with Matchers with IOSuite {
+  import CreateTopicProgramSpec._
 
-  private def metadataAlgebraF(
-                                metadataTopic: String,
-                                s: SchemaRegistry[IO],
-                                k: KafkaClientAlgebra[IO]
-                              ) = MetadataAlgebra.make(Subject.createValidated(metadataTopic).get, "consumerGroup", k, s, consumeMetadataEnabled = true)
-
-  private val keySchema = getSchema("key")
-  private val valueSchema = getSchema("val")
-
-  private def createTopicMetadataRequest(
-    keySchema: Schema,
-    valueSchema: Schema,
-    email: String = "test@test.com",
-    createdDate: Instant = Instant.now(),
-    deprecated: Boolean = false,
-    deprecatedDate: Option[Instant] = None,
-    numPartitions: Option[NumPartitions] = None,
-    tags: Option[Map[String,String]] = None
-  ): TopicMetadataV2Request =
-    TopicMetadataV2Request(
-      Schemas(keySchema, valueSchema),
-      StreamTypeV2.Entity,
-      deprecated = deprecated,
-      deprecatedDate,
-      Public,
-      NonEmptyList.of(Email.create(email).get),
-      createdDate,
-      List.empty,
-      None,
-      Some("dvs-teamName"),
-      numPartitions,
-      List.empty
-    )
-
-  private def createEventStreamTypeTopicMetadataRequest(
-                                          keySchema: Schema,
-                                          valueSchema: Schema,
-                                          email: String = "test@test.com",
-                                          createdDate: Instant = Instant.now(),
-                                          deprecated: Boolean = false,
-                                          deprecatedDate: Option[Instant] = None,
-                                          numPartitions: Option[NumPartitions] = None,
-                                          tags: Option[Map[String,String]] = None
-                                        ): TopicMetadataV2Request =
-    TopicMetadataV2Request(
-      Schemas(keySchema, valueSchema),
-      StreamTypeV2.Event,
-      deprecated = deprecated,
-      deprecatedDate,
-      Public,
-      NonEmptyList.of(Email.create(email).get),
-      createdDate,
-      List.empty,
-      None,
-      Some("dvs-teamName"),
-      numPartitions,
-      List.empty
-    )
-
-  "CreateTopicSpec" must {
+  "CreateTopicSpec" - {
     "register the two avro schemas" in {
-      val schemaRegistryIO = SchemaRegistry.test[IO]
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-
-      (for {
-        schemaRegistry <- schemaRegistryIO
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.v2Topic", schemaRegistry, kafkaClient)
-        registerInternalMetadata = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.v2Topic").get,
-          metadata
-        )
-        _ = registerInternalMetadata
-          .createTopic(
-            Subject.createValidated("dvs.subject").get,
-            createTopicMetadataRequest(keySchema, valueSchema),
-            TopicDetails(1, 1, 1)
-          )
-          .unsafeRunSync()
-        containsSingleKeyAndValue <- schemaRegistry.getAllSubjects.map(
-          _.length == 2
-        )
-      } yield assert(containsSingleKeyAndValue)).unsafeRunSync()
+      for {
+        ts          <- initTestServices()
+        _           <- ts.program.createTopic(subject, topicMetadataRequest, topicDetails)
+        allSubjects <- ts.schemaRegistry.getAllSubjects
+      } yield allSubjects.size shouldBe 2
     }
 
     "rollback schema creation on error" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-
-      case class TestState(
-                            deleteSchemaWasCalled: Boolean,
-                            numSchemasRegistered: Int
-                          )
+      case class TestState(deleteSchemaWasCalled: Boolean, numSchemasRegistered: Int)
 
       def getSchemaRegistry(ref: Ref[IO, TestState]): SchemaRegistry[IO] =
         new SchemaRegistry[IO] {
-          override def registerSchema(
-                                       subject: String,
-                                       schema: Schema
-                                     ): IO[SchemaId] = ref.get.flatMap {
-            case TestState(_, 1) =>
-              IO.raiseError(new Exception("Something horrible went wrong!"))
+          override def registerSchema(subject: String, schema: Schema): IO[SchemaId] = ref.get.flatMap {
+            case TestState(_, 1) => IO.raiseError(new Exception("Something horrible went wrong!"))
             case t: TestState =>
               val schemaId = t.numSchemasRegistered + 1
-              ref.set(t.copy(numSchemasRegistered = schemaId)) *> IO.pure(
-                schemaId
-              )
+              ref.set(t.copy(numSchemasRegistered = schemaId)) *> IO.pure(schemaId)
           }
-          override def deleteSchemaOfVersion(
-                                              subject: String,
-                                              version: SchemaVersion
-                                            ): IO[Unit] = ref.update(_.copy(deleteSchemaWasCalled = true))
-          override def getVersion(
-                                   subject: String,
-                                   schema: Schema
-                                 ): IO[SchemaVersion] = ref.get.map { testState =>
-            testState.numSchemasRegistered + 1
-          }
+
+          override def deleteSchemaOfVersion(subject: String, version: SchemaVersion): IO[Unit] =
+            ref.update(_.copy(deleteSchemaWasCalled = true))
+
+          override def getVersion(subject: String, schema: Schema): IO[SchemaVersion] =
+            ref.get.map(testState => testState.numSchemasRegistered + 1)
+
           override def getAllVersions(subject: String): IO[List[Int]] = IO.pure(List())
           override def getAllSubjects: IO[List[String]] = IO.pure(List())
-
-          override def getSchemaRegistryClient: IO[SchemaRegistryClient] = IO.raiseError(new Exception("Something horrible went wrong!"))
+          override def getSchemaRegistryClient: IO[SchemaRegistryClient] =
+            IO.raiseError(new Exception("Something horrible went wrong!"))
 
           override def getLatestSchemaBySubject(subject: String): IO[Option[Schema]] = IO.pure(None)
-
           override def getSchemaFor(subject: String, schemaVersion: SchemaVersion): IO[Option[Schema]] = IO.pure(None)
           override def deleteSchemaSubject(subject: String): IO[Unit] = IO.pure(())
         }
-      (for {
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        ref <- Ref[IO]
-          .of(TestState(deleteSchemaWasCalled = false, 0))
-        schemaRegistry = getSchemaRegistry(ref)
-        metadata <- metadataAlgebraF("_test.name", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-          .attempt
+      for {
+        ref    <- Ref[IO].of(TestState(deleteSchemaWasCalled = false, 0))
+        ts     <- initTestServices(schemaRegistry = getSchemaRegistry(ref).some)
+        _      <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchema), topicDetails).attempt
         result <- ref.get
-      } yield assert(result.deleteSchemaWasCalled)).unsafeRunSync()
+      } yield result.deleteSchemaWasCalled shouldBe true
     }
 
     "retry given number of attempts" in {
       val numberRetries = 3
-      val policy: RetryPolicy[IO] = RetryPolicies.limitRetries(numberRetries)
 
       def getSchemaRegistry(ref: Ref[IO, Int]): SchemaRegistry[IO] =
         new SchemaRegistry[IO] {
-          override def registerSchema(
-                                       subject: String,
-                                       schema: Schema
-                                     ): IO[SchemaId] = ref.get.flatMap { n =>
-            ref.set(n + 1) *> IO.raiseError(
-              new Exception("Something horrible went wrong!")
-            )
-          }
-          override def deleteSchemaOfVersion(
-                                              subject: String,
-                                              version: SchemaVersion
-                                            ): IO[Unit] = IO.unit
-          override def getVersion(
-                                   subject: String,
-                                   schema: Schema
-                                 ): IO[SchemaVersion] = IO.pure(1)
+          override def registerSchema(subject: String, schema: Schema): IO[SchemaId] =
+            ref.get.flatMap(n => ref.set(n + 1) *> IO.raiseError(new Exception("Something horrible went wrong!")))
+
+          override def deleteSchemaOfVersion(subject: String, version: SchemaVersion): IO[Unit] = IO.unit
+          override def getVersion(subject: String, schema: Schema): IO[SchemaVersion] = IO.pure(1)
           override def getAllVersions(subject: String): IO[List[Int]] = IO.pure(Nil)
           override def getAllSubjects: IO[List[String]] = IO.pure(Nil)
           override def getSchemaRegistryClient: IO[SchemaRegistryClient] = IO.raiseError(new Exception("Something horrible went wrong!"))
@@ -227,56 +99,29 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           override def deleteSchemaSubject(subject: String): IO[Unit] = IO.pure(())
         }
 
-      (for {
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        ref <- Ref[IO].of(0)
-        schemaRegistry = getSchemaRegistry(ref)
-        metadata <- metadataAlgebraF("_test.name", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-          .attempt
+      for {
+        ref    <- Ref[IO].of(0)
+        ts     <- initTestServices(schemaRegistry = getSchemaRegistry(ref).some, retryPolicy = RetryPolicies.limitRetries(numberRetries))
+        _      <-ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchema), topicDetails).attempt
         result <- ref.get
-      } yield result shouldBe numberRetries + 1).unsafeRunSync()
+      } yield result shouldBe numberRetries + 1
     }
 
     "not remove existing schemas on rollback" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-
       type SchemaName = String
       case class TestState(schemas: Map[SchemaName, SchemaVersion])
 
       def getSchemaRegistry(ref: Ref[IO, TestState]): SchemaRegistry[IO] =
         new SchemaRegistry[IO] {
-          override def registerSchema(
-                                       subject: String,
-                                       schema: Schema
-                                     ): IO[SchemaId] = ref.get.flatMap { ts =>
-            if (subject.contains("-value")) {
-              IO.raiseError(new Exception)
-            } else {
-              IO.pure(ts.schemas(subject))
+          override def registerSchema(subject: String, schema: Schema): IO[SchemaId] =
+            ref.get.flatMap { ts =>
+              if (subject.contains("-value")) IO.raiseError(new Exception) else IO.pure(ts.schemas(subject))
             }
-          }
-          override def deleteSchemaOfVersion(
-                                              subject: String,
-                                              version: SchemaVersion
-                                            ): IO[Unit] =
+
+          override def deleteSchemaOfVersion(subject: String, version: SchemaVersion): IO[Unit] =
             ref.update(ts => ts.copy(schemas = ts.schemas - subject))
-          override def getVersion(
-                                   subject: String,
-                                   schema: Schema
-                                 ): IO[SchemaVersion] = ref.get.map(_.schemas(subject))
+
+          override def getVersion(subject: String, schema: Schema): IO[SchemaVersion] = ref.get.map(_.schemas(subject))
           override def getAllVersions(subject: String): IO[List[Int]] = IO.pure(Nil)
           override def getAllSubjects: IO[List[String]] = IO.pure(Nil)
           override def getSchemaRegistryClient: IO[SchemaRegistryClient] = IO.raiseError(new Exception)
@@ -286,277 +131,123 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
         }
 
       val schemaRegistryState = Map("subject-key" -> 1)
-      (for {
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        ref <- Ref[IO]
-          .of(TestState(schemaRegistryState))
-        schemaRegistry = getSchemaRegistry(ref)
-        metadata <- metadataAlgebraF("_test.name", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-          .attempt
+      for {
+        ref    <- Ref[IO].of(TestState(schemaRegistryState))
+        ts     <- initTestServices(schemaRegistry = getSchemaRegistry(ref).some)
+        _      <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchema), topicDetails).attempt
         result <- ref.get
-      } yield result.schemas shouldBe schemaRegistryState).unsafeRunSync()
+      } yield result.schemas shouldBe schemaRegistryState
     }
 
     "create the topic in Kafka" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = "dvs.subject"
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        topic <- kafka.describeTopic(subject)
-      } yield topic.get shouldBe Topic(subject, 1)).unsafeRunSync()
+      for {
+        ts    <- initTestServices()
+        _     <- ts.program.createTopic(subject, topicMetadataRequest, topicDetails)
+        topic <- ts.kafka.describeTopic(subject.value)
+      } yield topic.get shouldBe Topic(subject.value, 1)
     }
 
     "ingest metadata into the metadata topic" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val metadataTopic = "dvs.test-metadata-topic"
-      val request = createTopicMetadataRequest(keySchema, valueSchema)
-      val key = TopicMetadataV2Key(subject)
-      val value = request.toValue
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(publishTo)
-        )
-        m <- TopicMetadataV2.encode[IO](key, Some(value))
-        metadata <- metadataAlgebraF(metadataTopic, schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry = schemaRegistry,
-          kafkaAdmin = kafkaAdmin,
-          kafkaClient = kafkaClient,
-          retryPolicy = policy,
-          v2MetadataTopicName = Subject.createValidated(metadataTopic).get,
-          metadata
-        ).createTopic(subject, request, TopicDetails(1, 1, 1))
-        published <- publishTo.get
-      } yield published shouldBe Map(metadataTopic -> (m._1, m._2, None))).unsafeRunSync()
+      for {
+        publishTo     <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
+        topicMetadata <- TopicMetadataV2.encode[IO](topicMetadataKey, Some(topicMetadataValue))
+        ts            <- initTestServices(new TestKafkaClientAlgebraWithPublishTo(publishTo).some)
+        _             <- ts.program.createTopic(subject, topicMetadataRequest, topicDetails)
+        published     <- publishTo.get
+      } yield published shouldBe Map(metadataTopic -> (topicMetadata._1, topicMetadata._2, None))
     }
 
     "ingest updated metadata into the metadata topic - verify created date did not change" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val metadataTopic = "dvs.test-metadata-topic"
-      val request = createTopicMetadataRequest(keySchema, valueSchema)
-      val key = TopicMetadataV2Key(subject)
-      val value = request.toValue
       val updatedRequest = createTopicMetadataRequest(keySchema, valueSchema, "updated@email.com", Instant.ofEpochSecond(0))
-      val updatedKey = TopicMetadataV2Key(subject)
-      val updatedValue = updatedRequest.toValue
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(publishTo)
-        )
+      val updatedValue   = updatedRequest.toValue
+      for {
+        publishTo   <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
         consumeFrom <- Ref[IO].of(Map.empty[Subject, TopicMetadataContainer])
-        metadata <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
-        m <- TopicMetadataV2.encode[IO](key, Some(value))
-        updatedM <- TopicMetadataV2.encode[IO](updatedKey, Some(updatedValue.copy(createdDate = value.createdDate)))
-        createTopicProgram = new CreateTopicProgram[IO](
-          schemaRegistry = schemaRegistry,
-          kafkaAdmin = kafkaAdmin,
-          kafkaClient = kafkaClient,
-          retryPolicy = policy,
-          v2MetadataTopicName = Subject.createValidated(metadataTopic).get,
-          metadata
-        )
-        _ <- createTopicProgram.createTopic(subject, request, TopicDetails(1, 1, 1))
-        _ <- metadata.addToMetadata(subject, request)
+        metadata    <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
+        m           <- TopicMetadataV2.encode[IO](topicMetadataKey, Some(topicMetadataValue))
+        updatedM    <- TopicMetadataV2.encode[IO](topicMetadataKey, Some(updatedValue.copy(createdDate = topicMetadataValue.createdDate)))
+        ts          <- initTestServices(new TestKafkaClientAlgebraWithPublishTo(publishTo).some, metadata.some)
+        _           <- ts.program.createTopic(subject, topicMetadataRequest, TopicDetails(1, 1, 1))
+        _           <- metadata.addToMetadata(subject, topicMetadataRequest)
         metadataMap <- publishTo.get
-        _ <- createTopicProgram.createTopic(subject, updatedRequest, TopicDetails(1, 1, 1))
-        updatedMap <- publishTo.get
+        _           <- ts.program.createTopic(subject, updatedRequest, TopicDetails(1, 1, 1))
+        updatedMap  <- publishTo.get
       } yield {
         metadataMap shouldBe Map(metadataTopic -> (m._1, m._2, None))
         updatedMap shouldBe Map(metadataTopic -> (updatedM._1, updatedM._2, None))
-      }).unsafeRunSync()
+      }
     }
 
     "rollback kafka topic creation when error encountered in publishing metadata" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = "dvs.subject"
-      val metadataTopic = "dvs.test-metadata-topic"
-      val request = createTopicMetadataRequest(keySchema, valueSchema)
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(
-            publishTo,
-            failOnPublish = true
-          )
-        )
-        metadata <- metadataAlgebraF(metadataTopic, schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafkaAdmin,
-          kafkaClient,
-          policy,
-          Subject.createValidated(metadataTopic).get,
-          metadata
-        ).createTopic(Subject.createValidated(subject).get, request, TopicDetails(1, 1, 1)).attempt
-        topic <- kafkaAdmin.describeTopic(subject)
-      } yield topic should not be defined).unsafeRunSync()
+      for {
+        publishTo   <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
+        kafkaClient = new TestKafkaClientAlgebraWithPublishTo(publishTo, failOnPublish = true)
+        ts          <- initTestServices(kafkaClient.some)
+        _           <- ts.program.createTopic(subject, topicMetadataRequest, topicDetails).attempt
+        topic       <- ts.kafka.describeTopic(subject.value)
+      } yield topic.isDefined shouldBe false
     }
 
     "not delete an existing topic when rolling back" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = "dvs.subject"
-      val metadataTopic = "dvs.test-metadata-topic"
-      val topicDetails = TopicDetails(1, 1, 1)
-      val request = createTopicMetadataRequest(keySchema, valueSchema)
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(
-            publishTo,
-            failOnPublish = true
-          )
-        )
-        _ <- kafkaAdmin.createTopic(subject, topicDetails)
-        metadata <- metadataAlgebraF(metadataTopic, schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafkaAdmin,
-          kafkaClient,
-          policy,
-          Subject.createValidated(metadataTopic).get,
-          metadata
-        ).createTopic(Subject.createValidated(subject).get, request, topicDetails).attempt
-        topic <- kafkaAdmin.describeTopic(subject)
-      } yield topic shouldBe defined).unsafeRunSync()
+      for {
+        publishTo   <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
+        kafkaClient = new TestKafkaClientAlgebraWithPublishTo(publishTo, failOnPublish = true)
+        ts          <- initTestServices(kafkaClient.some)
+        _           <- ts.kafka.createTopic(subject.value, topicDetails)
+        _           <- ts.program.createTopic(subject, topicMetadataRequest, topicDetails).attempt
+        topic       <- ts.kafka.describeTopic(subject.value)
+      } yield topic.isDefined shouldBe true
     }
 
     "ingest updated metadata into the metadata topic - verify deprecated date if supplied is not overwritten" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val metadataTopic = "_test.metadata-topic"
-      val request = createTopicMetadataRequest(keySchema, valueSchema, deprecated = true, deprecatedDate = Some(Instant.now))
+      val request        = createTopicMetadataRequest(keySchema, valueSchema, deprecated = true, deprecatedDate = Some(Instant.now))
       val updatedRequest = createTopicMetadataRequest(keySchema, valueSchema, "updated@email.com", deprecated = true)
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(publishTo)
-        )
+      for {
+        publishTo   <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
         consumeFrom <- Ref[IO].of(Map.empty[Subject, TopicMetadataContainer])
-        metadata <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
-        createTopicProgram = new CreateTopicProgram[IO](
-          schemaRegistry = schemaRegistry,
-          kafkaAdmin = kafkaAdmin,
-          kafkaClient = kafkaClient,
-          retryPolicy = policy,
-          v2MetadataTopicName = Subject.createValidated(metadataTopic).get,
-          metadata
-        )
-        _ <- createTopicProgram.createTopic(subject, request, TopicDetails(1, 1, 1))
-        _ <- metadata.addToMetadata(subject, request)
+        metadata    <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
+        ts          <- initTestServices(new TestKafkaClientAlgebraWithPublishTo(publishTo).some, metadata.some)
+        _           <- ts.program.createTopic(subject, request, topicDetails)
+        _           <- metadata.addToMetadata(subject, request)
         metadataMap <- publishTo.get
-        _ <- createTopicProgram.createTopic(subject, updatedRequest, TopicDetails(1, 1, 1))
-        updatedMap <- publishTo.get
+        _           <- ts.program.createTopic(subject, updatedRequest, topicDetails)
+        updatedMap  <- publishTo.get
       } yield {
-        val dd = metadataMap(metadataTopic)._2.get.get("deprecatedDate")
-        val ud = updatedMap(metadataTopic)._2.get.get("deprecatedDate")
-        ud shouldBe dd
-      }).unsafeRunSync()
+        updatedMap(metadataTopic)._2.get.get("deprecatedDate") shouldBe metadataMap(metadataTopic)._2.get.get("deprecatedDate")
+      }
     }
 
     "ingest updated metadata into the metadata topic - verify deprecated date is updated when starting with None" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val metadataTopic = "_test.metadata-topic"
       val request = createTopicMetadataRequest(keySchema, valueSchema)
       val updatedRequest = createTopicMetadataRequest(keySchema, valueSchema, "updated@email.com", deprecated = true)
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafkaAdmin <- KafkaAdminAlgebra.test[IO]()
-        publishTo <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
-        kafkaClient <- IO(
-          new TestKafkaClientAlgebraWithPublishTo(publishTo)
-        )
+      for {
+        publishTo   <- Ref[IO].of(Map.empty[String, (GenericRecord, Option[GenericRecord], Option[Headers])])
         consumeFrom <- Ref[IO].of(Map.empty[Subject, TopicMetadataContainer])
-        metadata <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
-        createTopicProgram = new CreateTopicProgram[IO](
-          schemaRegistry = schemaRegistry,
-          kafkaAdmin = kafkaAdmin,
-          kafkaClient = kafkaClient,
-          retryPolicy = policy,
-          v2MetadataTopicName = Subject.createValidated(metadataTopic).get,
-          metadata
-        )
-        _ <- createTopicProgram.createTopic(subject, request, TopicDetails(1, 1, 1))
-        _ <- metadata.addToMetadata(subject, request)
+        metadata    <- IO(new TestMetadataAlgebraWithPublishTo(consumeFrom))
+        ts          <- initTestServices(new TestKafkaClientAlgebraWithPublishTo(publishTo).some, metadata.some)
+        _           <- ts.program.createTopic(subject, request, topicDetails)
+        _           <- metadata.addToMetadata(subject, request)
         metadataMap <- publishTo.get
-        _ <- createTopicProgram.createTopic(subject, updatedRequest, TopicDetails(1, 1, 1))
-        updatedMap <- publishTo.get
+        _           <- ts.program.createTopic(subject, updatedRequest, topicDetails)
+        updatedMap  <- publishTo.get
       } yield {
         val ud = metadataMap(metadataTopic)._2.get.get("deprecatedDate")
         val dd = updatedMap(metadataTopic)._2.get.get("deprecatedDate")
         ud shouldBe null
         Instant.parse(dd.toString) shouldBe a[Instant]
-      }).unsafeRunSync()
+      }
     }
 
     "create topic with custom number of partitions" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = "dvs.subject"
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchema, numPartitions = refineMV[TopicMetadataV2Request.NumPartitionsPredicate](22).some),
-          TopicDetails(1, 1, 1)
-        )
-        topic <- kafka.describeTopic(subject)
-      } yield topic.get shouldBe Topic(subject, 22)).unsafeRunSync()
+      for {
+        ts      <- initTestServices()
+        request = createTopicMetadataRequest(keySchema, valueSchema, numPartitions = refineMV[TopicMetadataV2Request.NumPartitionsPredicate](22).some)
+        _       <- ts.program.createTopic(subject, request, topicDetails)
+        topic   <- ts.kafka.describeTopic(subject.value)
+      } yield topic.get shouldBe Topic(subject.value, 22)
     }
 
     "throw error on topic with key and value field named same but with different type" in {
-
       val mismatchedValueSchema =
         SchemaBuilder
           .record("name")
@@ -567,25 +258,14 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .noDefault()
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, mismatchedValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, mismatchedValueSchema), topicDetails)
+      } yield ()
+
+      val keyFieldSchema   = keySchema.getField("isTrue").schema()
+      val valueFieldSchema = mismatchedValueSchema.getField("isTrue").schema()
+      result.attempt.map(_ shouldBe IncompatibleKeyAndValueFieldNamesError("isTrue", keyFieldSchema, valueFieldSchema).asLeft)
     }
 
     "throw error on topic with key that has field of type union [null, ...]" in {
@@ -599,25 +279,13 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .withDefault(null)
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(recordWithNullDefault, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(recordWithNullDefault, recordWithNullDefault), topicDetails)
+      } yield ()
+
+      val fieldSchema = recordWithNullDefault.getField("nullableUnion").schema()
+      result.attempt.map(_ shouldBe KeyHasNullableFieldError("nullableUnion", fieldSchema).asLeft)
     }
 
     "do not throw error on topic with key that has field of type union [null, ...] if streamType is 'Event'" in {
@@ -631,25 +299,10 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .withDefault(null)
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createEventStreamTypeTopicMetadataRequest(recordWithNullDefault, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createEventStreamTypeTopicMetadataRequest(recordWithNullDefault, recordWithNullDefault), topicDetails)
+      } yield succeed
     }
 
     "throw error on topic with key that has field of type null" in {
@@ -662,25 +315,13 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .noDefault()
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(recordWithNullType, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(recordWithNullType, recordWithNullType), topicDetails)
+      } yield ()
+
+      val fieldSchema = recordWithNullType.getField("nullableField").schema()
+      result.attempt.map(_ shouldBe KeyHasNullableFieldError("nullableField", fieldSchema).asLeft)
     }
 
     "do not throw error on topic with key that has field of type null if streamType is 'Event'" in {
@@ -693,25 +334,10 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .noDefault()
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createEventStreamTypeTopicMetadataRequest(recordWithNullType, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createEventStreamTypeTopicMetadataRequest(recordWithNullType, recordWithNullType), topicDetails)
+      } yield succeed
     }
 
     "throw error on schema evolution with illegal union logical type removal" in {
@@ -723,16 +349,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |        "name":"context",
-          |        "type":[
-          |                 {
-          |                   "type": "string",
-          |                   "logicalType": "uuid"
-          |                 },
-          |                 "null"
-          |               ]
-          |     },
-          |     {
-          |        "name":"context2",
+          |        "default": "abc",
           |        "type":[
           |                 {
           |                   "type": "string",
@@ -743,7 +360,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -752,43 +369,23 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |       "name": "context",
-          |       "type": ["string", "null" ]
-          |     },
-          |     {
-          |       "name": "context2",
+          |       "default": "abc",
           |       "type": ["string", "null" ]
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "null", "context").asLeft)
+    }
 
     "throw error on schema evolution with illegal union logical type addition" in {
       val firstValue =
@@ -799,10 +396,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |       "name": "context",
-          |       "type": ["string", "null" ]
-          |     },
-          |     {
-          |       "name": "context2",
+          |       "default": "abc",
           |       "type": ["string", "null" ]
           |     }
           |  ]
@@ -816,16 +410,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |        "name":"context",
-          |        "type":[
-          |                 {
-          |                   "type": "string",
-          |                   "logicalType": "uuid"
-          |                 },
-          |                 "null"
-          |               ]
-          |     },
-          |     {
-          |        "name":"context2",
+          |        "default": "abc",
           |        "type":[
           |                 {
           |                   "type": "string",
@@ -841,31 +426,14 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("null", "uuid", "context").asLeft)
+    }
 
     "throw error on schema evolution with illegal union logical type change" in {
       val firstValue =
@@ -876,16 +444,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |        "name":"context",
-          |        "type":[
-          |                 {
-          |                   "type": "string",
-          |                   "logicalType": "uuid"
-          |                 },
-          |                 "null"
-          |               ]
-          |     },
-          |     {
-          |        "name":"context2",
+          |        "default": "abc",
           |        "type":[
           |                 {
           |                   "type": "string",
@@ -905,16 +464,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "fields": [
           |     {
           |        "name":"context",
-          |        "type":[
-          |                 {
-          |                   "type": "string",
-          |                   "logicalType": "date"
-          |                 },
-          |                 "null"
-          |               ]
-          |     },
-          |     {
-          |        "name":"context2",
+          |        "default": "abc",
           |        "type":[
           |                 {
           |                   "type": "string",
@@ -930,31 +480,14 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "date", "context").asLeft)
+    }
 
     "throw error on schema evolution with illegal key field logical type change string" in {
       val firstKey =
@@ -989,34 +522,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstKeySchema = new Schema.Parser().parse(firstKey)
       val keySchemaEvolution = new Schema.Parser().parse(keyEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(firstKeySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchemaEvolution, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(firstKeySchema, valueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchemaEvolution, valueSchema), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "date", "keyThing").asLeft)
+    }
 
     "throw error on schema evolution with illegal value field logical type removal" in {
       val firstValue =
@@ -1034,7 +551,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |    }
           |  ]
           |}
-    """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1047,35 +564,19 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |    }
           |  ]
           |}
-    """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "null", "valueThing").asLeft)
+    }
 
     "throw error on schema evolution with illegal value array with field logical type removal" in {
       val firstValue =
@@ -1097,7 +598,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1116,35 +617,19 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("date", "null", "ArrayOfThings").asLeft)
+    }
 
     "throw error on schema evolution with illegal value map with field logical type removal" in {
       val firstValue =
@@ -1154,7 +639,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "name": "test",
           |  "fields": [
           |     {
-          |       "name": "ArrayOfThings",
+          |       "name": "MapOfThings",
           |       "type": {
           |         "type": "map",
           |         "values":
@@ -1166,7 +651,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1174,7 +659,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  "name": "test",
           |  "fields": [
           |     {
-          |       "name": "ArrayOfThings",
+          |       "name": "MapOfThings",
           |       "type": {
           |         "type": "map",
           |         "values":
@@ -1185,36 +670,19 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield  fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
 
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("date", "null", "MapOfThings").asLeft)
+    }
 
     "do not throw logical type validation error on schema evolution with no change, array" in {
       val firstValue =
@@ -1236,7 +704,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1256,35 +724,17 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()}
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield succeed
+    }
 
     "do not throw logical type validation error on schema evolution with no change, map" in {
       val firstValue =
@@ -1306,7 +756,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1326,35 +776,17 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()}
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield succeed
+    }
 
     "do not throw logical type validation error on schema evolution with no change, nested record" in {
       val firstValue =
@@ -1378,7 +810,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
       val valueEvolution =
         """
           |{
@@ -1400,35 +832,17 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |     }
           |  ]
           |}
-  """.stripMargin
+      """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        tcp = new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- tcp.createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()}
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield succeed
+    }
 
     "throw error on schema evolution with illegal key field logical type change within a nested record" in {
       val firstKey =
@@ -1478,41 +892,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstKeySchema = new Schema.Parser().parse(firstKey)
       val keySchemaEvolution = new Schema.Parser().parse(keyEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(firstKeySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchemaEvolution, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(firstKeySchema, valueSchema), topicDetails)
+        _ <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchemaEvolution, valueSchema), topicDetails)
+      } yield ()
 
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("uuid", "null", "address").asLeft)
+    }
 
     "throw error on schema evolution with illegal key field logical type change" in {
       val firstKey =
@@ -1547,40 +938,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstKeySchema = new Schema.Parser().parse(firstKey)
       val keySchemaEvolution = new Schema.Parser().parse(keyEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(firstKeySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchemaEvolution, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(firstKeySchema, valueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchemaEvolution, valueSchema), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("timestamp-millis", "timestamp-micros", "keyThing").asLeft)
+    }
 
     "throw error on schema evolution with illegal value field logical type change" in {
       val firstValue =
@@ -1615,40 +984,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("timestamp-millis", "timestamp-micros", "valueThing").asLeft)
+    }
 
     "throw error on schema evolution with illegal key field logical type addition" in {
       val firstKey =
@@ -1682,40 +1029,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstKeySchema = new Schema.Parser().parse(firstKey)
       val keySchemaEvolution = new Schema.Parser().parse(keyEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(firstKeySchema, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchemaEvolution, valueSchema),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(firstKeySchema, valueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchemaEvolution, valueSchema), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("null", "uuid", "valueThing").asLeft)
+    }
 
     "throw error on schema evolution with illegal value field logical type addition" in {
       val firstValue =
@@ -1749,40 +1074,18 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe IllegalLogicalTypeChangeError("null", "uuid", "valueThing").asLeft)
+    }
 
     "do not throw error on legal schema evolution with enum" in {
       val firstValue =
@@ -1821,41 +1124,16 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           |  ]
           |}
       """.stripMargin
+
       val firstValueSchema = new Schema.Parser().parse(firstValue)
       val valueSchemaEvolution = new Schema.Parser().parse(valueEvolution)
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      (for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, firstValueSchema),
-          TopicDetails(1, 1, 1)
-        )
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, valueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        )
-      } yield succeed).unsafeRunSync()}
-
+      for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, firstValueSchema), topicDetails)
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, valueSchemaEvolution), topicDetails)
+      } yield succeed
+    }
 
     "successfully validate topic schema with value that has field of type union [null, ...]" in {
       val union = SchemaBuilder.unionOf().nullType().and().stringType().endUnion()
@@ -1868,23 +1146,15 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .withDefault(null)
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(keySchema, recordWithNullDefault)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,keySchema, recordWithNullDefault)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield (succeed))
-      resource.use(_ => Bracket[IO, Throwable].unit).unsafeRunSync()
+      for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject ,keySchema, recordWithNullDefault)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(keySchema, recordWithNullDefault)))
+      } yield succeed
     }
 
-    "succesfully validate topic schema with value that has field of type null" in {
+    "successfully validate topic schema with value that has field of type null" in {
       val recordWithNullType =
         SchemaBuilder
           .record("name")
@@ -1894,23 +1164,15 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .noDefault()
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(keySchema, recordWithNullType)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,keySchema, recordWithNullType)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield (succeed))
-      resource.use(_ => Bracket[IO, Throwable].unit).unsafeRunSync()
+      for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject, keySchema, recordWithNullType)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(keySchema, recordWithNullType)))
+      } yield succeed
     }
 
-    "succesfully validate topic schema with key that has field of type union [not null, not null]" in {
+    "successfully validate topic schema with key that has field of type union [not null, not null]" in {
       val union = SchemaBuilder.unionOf().intType().and().stringType().endUnion()
       val recordWithNullDefault =
         SchemaBuilder
@@ -1921,104 +1183,78 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
           .withDefault(5)
           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(recordWithNullDefault, valueSchema)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject, recordWithNullDefault, valueSchema)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield (succeed))
-      resource.use(_ => Bracket[IO, Throwable].unit).unsafeRunSync()
+      for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject, recordWithNullDefault, valueSchema)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(recordWithNullDefault, valueSchema)))
+      } yield succeed
     }
 
-    /*"successfully evolve schema which had mismatched types in past version" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val mismatchedValueSchema = SchemaBuilder.record("name").fields().name("isTrue").`type`().booleanType().noDefault().endRecord()
-      val mismatchedValueSchemaEvolution = SchemaBuilder.record("name").fields().name("isTrue").`type`().booleanType().noDefault().nullableInt("nullInt", 12).endRecord()
-      val topicMetadataV2Request = createTopicMetadataRequest(keySchema, mismatchedValueSchema)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,keySchema, mismatchedValueSchema)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-        _ <- Resource.liftF(ctProgram.createTopic(
-          subject,
-          createTopicMetadataRequest(keySchema, mismatchedValueSchemaEvolution),
-          TopicDetails(1, 1, 1)
-        ))
-      } yield (succeed))
-      resource.use(_ => Bracket[IO, Throwable].unit).unsafeRunSync()
-    }*/
+    "successfully evolve schema which had mismatched types in past version" ignore {
+      val mismatchedValueSchema =
+        SchemaBuilder
+          .record("name")
+          .fields()
+          .name("isTrue")
+          .`type`().booleanType().noDefault().endRecord()
+      val mismatchedValueSchemaEvolution =
+        SchemaBuilder
+          .record("name")
+          .fields()
+          .name("isTrue")
+          .`type`().booleanType().noDefault().nullableInt("nullInt", 12).endRecord()
+
+      for {
+        ts <- Resource.liftF(initTestServices())
+        _ <- ts.program.registerSchemas(subject ,keySchema, mismatchedValueSchema)
+        _ <- ts.program.createTopicResource(subject, topicDetails)
+        _ <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(keySchema, mismatchedValueSchema)))
+        _ <- Resource.liftF(ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, mismatchedValueSchemaEvolution), topicDetails))
+      } yield succeed
+    }
 
     "throw error if key schema is not registered as record type before creating topic from metadata only" in {
       val incorrectKeySchema = new Schema.Parser().parse("""
                                                            |{
                                                            |	"type": "string"
                                                            |}""".stripMargin)
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(incorrectKeySchema, valueSchema)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,incorrectKeySchema, valueSchema)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield fail("Should Fail to add Metadata - this yield should not be hit."))}
+      val result = for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject, incorrectKeySchema, valueSchema)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(incorrectKeySchema, valueSchema)))
+      } yield ()
+
+      result.attempt.map(_ shouldBe TopicSchemaError.InvalidSchemaTypeError.asLeft)
+    }
 
     "throw error if value schema is not registered as record type before creating topic from metadata only" in {
       val incorrectValueSchema = new Schema.Parser().parse("""
                                                              |{
                                                              |	"type": "string"
                                                              |}""".stripMargin)
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(keySchema, incorrectValueSchema)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,keySchema, incorrectValueSchema)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield fail("Should Fail to add Metadata - this yield should not be hit."))}
+      val result = for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject, keySchema, incorrectValueSchema)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, createTopicMetadataRequest(keySchema, incorrectValueSchema)))
+      } yield ()
+
+      result.attempt.map(_ shouldBe TopicSchemaError.InvalidSchemaTypeError.asLeft)
+    }
 
     "successfully creating topic from metadata only where key and value schemas are records" in {
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      val subject = Subject.createValidated("dvs.subject").get
-      val topicMetadataV2Request = createTopicMetadataRequest(keySchema, valueSchema)
-      val resource: Resource[IO, Assertion] = (for {
-        schemaRegistry <- Resource.liftF(SchemaRegistry.test[IO])
-        kafka <- Resource.liftF(KafkaAdminAlgebra.test[IO]())
-        kafkaClient <- Resource.liftF(KafkaClientAlgebra.test[IO])
-        metadata <- Resource.liftF(metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient))
-        ctProgram = new CreateTopicProgram[IO](schemaRegistry, kafka, kafkaClient, policy, Subject.createValidated("dvs.test-metadata-topic").get, metadata)
-        _ <- ctProgram.registerSchemas(subject ,keySchema, valueSchema)
-        _ <- ctProgram.createTopicResource(subject, TopicDetails(1,1,1))
-        _ <- Resource.liftF(ctProgram.createTopicFromMetadataOnly(subject, topicMetadataV2Request))
-      } yield (succeed))
-      resource.use(_ => Bracket[IO, Throwable].unit).unsafeRunSync()
+      for {
+        ts <- Resource.liftF(initTestServices())
+        _  <- ts.program.registerSchemas(subject ,keySchema, valueSchema)
+        _  <- ts.program.createTopicResource(subject, topicDetails)
+        _  <- Resource.liftF(ts.program.createTopicFromMetadataOnly(subject, topicMetadataRequest))
+      } yield succeed
     }
 
     "throw error of schema nullable values don't have default value" in {
       val union = SchemaBuilder.unionOf().nullType().and().stringType().endUnion()
-
       val nullableValue = SchemaBuilder
                           .record("val")
                           .fields()
@@ -2027,32 +1263,19 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
                           .noDefault()
                           .endRecord()
 
-      val policy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp
-      an [ValidationErrors] shouldBe thrownBy {(for {
-        schemaRegistry <- SchemaRegistry.test[IO]
-        kafka <- KafkaAdminAlgebra.test[IO]()
-        kafkaClient <- KafkaClientAlgebra.test[IO]
-        metadata <- metadataAlgebraF("dvs.test-metadata-topic", schemaRegistry, kafkaClient)
-        _ <- new CreateTopicProgram[IO](
-          schemaRegistry,
-          kafka,
-          kafkaClient,
-          policy,
-          Subject.createValidated("dvs.test-metadata-topic").get,
-          metadata
-        ).createTopic(
-          Subject.createValidated("dvs.subject").get,
-          createTopicMetadataRequest(keySchema, nullableValue),
-          TopicDetails(1, 1, 1)
-        )
-      } yield fail("Should Fail to Create Topic - this yield should not be hit.")).unsafeRunSync()}
+      val result = for {
+        ts <- initTestServices()
+        _  <- ts.program.createTopic(subject, createTopicMetadataRequest(keySchema, nullableValue), topicDetails)
+      } yield ()
+
+      result.attempt.map(_ shouldBe NullableFieldWithoutDefaultValueError("itsnullable", nullableValue.getFields.asScala.head.schema()).asLeft)
     }
   }
 
-  private final class TestKafkaClientAlgebraWithPublishTo(
-                                                           publishTo: Ref[IO, Map[TopicName, Record]],
-                                                           failOnPublish: Boolean = false
-                                                         ) extends KafkaClientAlgebra[IO] {
+  type Record = (GenericRecord, Option[GenericRecord], Option[Headers])
+
+  private final class TestKafkaClientAlgebraWithPublishTo(publishTo: Ref[IO, Map[TopicName, Record]], failOnPublish: Boolean = false)
+    extends KafkaClientAlgebra[IO] {
 
     override def publishMessage(record: Record, topicName: TopicName): IO[Either[PublishError, PublishResponse]] =
       if (failOnPublish) {
@@ -2077,6 +1300,7 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
 
     override def streamAvroKeyFromGivenPartitionAndOffset(topicName: TopicName, consumerGroup: ConsumerGroup, commitOffsets: Boolean, topicAndPartition: List[(TopicPartition, Offset)]): fs2.Stream[IO, ((GenericRecord, Option[GenericRecord], Option[Headers]), (Partition, Offset), Timestamp)] = ???
   }
+
   private final class TestMetadataAlgebraWithPublishTo(consumeFrom: Ref[IO, Map[Subject, TopicMetadataContainer]]) extends MetadataAlgebra[IO] {
     override def getMetadataFor(subject: Subject): IO[Option[MetadataAlgebra.TopicMetadataContainer]] = consumeFrom.get.map(_.get(subject))
 
@@ -2085,8 +1309,107 @@ class CreateTopicProgramSpec extends AnyWordSpecLike with Matchers {
     def addToMetadata(subject: Subject, t: TopicMetadataV2Request): IO[Unit] =
       consumeFrom.update(_ + (subject -> TopicMetadataContainer(TopicMetadataV2Key(subject), t.toValue, None, None)))
   }
+}
 
-  private def getSchema(name: String): Schema =
+object CreateTopicProgramSpec {
+  val keySchema     = getSchema("key")
+  val valueSchema   = getSchema("val")
+  val metadataTopic = "dvs.test-metadata-topic"
+
+  val subject              = Subject.createValidated("dvs.subject").get
+  val topicMetadataRequest = createTopicMetadataRequest(keySchema, valueSchema)
+  val topicDetails         = TopicDetails(1, 1, 1)
+  val topicMetadataKey     = TopicMetadataV2Key(subject)
+  val topicMetadataValue   = topicMetadataRequest.toValue
+
+  implicit val contextShift: ContextShift[IO]   = IO.contextShift(ExecutionContext.global)
+  implicit val concurrentEffect: Concurrent[IO] = IO.ioConcurrentEffect
+  implicit val timer: Timer[IO]                 = IO.timer(ExecutionContext.global)
+
+  implicit private def unsafeLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLogger[F]
+
+  case class TestServices(program: CreateTopicProgram[IO], schemaRegistry: SchemaRegistry[IO], kafka: KafkaAdminAlgebra[IO])
+
+  def initTestServices(kafkaClientOpt: Option[KafkaClientAlgebra[IO]] = None,
+                       metadataAlgebraOpt: Option[MetadataAlgebra[IO]] = None,
+                       schemaRegistry: Option[SchemaRegistry[IO]] = None,
+                       retryPolicy: RetryPolicy[IO] = RetryPolicies.alwaysGiveUp): IO[TestServices] = {
+    for {
+      defaultSchemaRegistry <- SchemaRegistry.test[IO]
+      kafka                 <- KafkaAdminAlgebra.test[IO]()
+      defaultKafkaClient    <- KafkaClientAlgebra.test[IO]
+      kafkaClient           = kafkaClientOpt.getOrElse(defaultKafkaClient)
+      defaultMetadata       <- metadataAlgebraF(metadataTopic, defaultSchemaRegistry, kafkaClient)
+    } yield {
+      val createTopicProgram =
+        new CreateTopicProgram[IO](
+          schemaRegistry.getOrElse(defaultSchemaRegistry),
+          kafka,
+          kafkaClient,
+          retryPolicy,
+          Subject.createValidated(metadataTopic).get,
+          metadataAlgebraOpt.getOrElse(defaultMetadata),
+          KeyAndValueSchemaV2Validator.make(defaultSchemaRegistry)
+        )
+
+      TestServices(createTopicProgram, defaultSchemaRegistry, kafka)
+    }
+  }
+
+  def metadataAlgebraF(metadataTopic: String,
+                       schemaRegistry: SchemaRegistry[IO],
+                       kafkaClient: KafkaClientAlgebra[IO]): IO[MetadataAlgebra[IO]] =
+    MetadataAlgebra.make(Subject.createValidated(metadataTopic).get, "consumerGroup", kafkaClient, schemaRegistry, consumeMetadataEnabled = true)
+
+  def createTopicMetadataRequest(
+                                  keySchema: Schema,
+                                  valueSchema: Schema,
+                                  email: String = "test@test.com",
+                                  createdDate: Instant = Instant.now(),
+                                  deprecated: Boolean = false,
+                                  deprecatedDate: Option[Instant] = None,
+                                  numPartitions: Option[NumPartitions] = None
+                                ): TopicMetadataV2Request =
+    TopicMetadataV2Request(
+      Schemas(keySchema, valueSchema),
+      StreamTypeV2.Entity,
+      deprecated = deprecated,
+      deprecatedDate,
+      Public,
+      NonEmptyList.of(Email.create(email).get),
+      createdDate,
+      List.empty,
+      None,
+      Some("dvs-teamName"),
+      numPartitions,
+      List.empty
+    )
+
+  def createEventStreamTypeTopicMetadataRequest(
+                                                 keySchema: Schema,
+                                                 valueSchema: Schema,
+                                                 email: String = "test@test.com",
+                                                 createdDate: Instant = Instant.now(),
+                                                 deprecated: Boolean = false,
+                                                 deprecatedDate: Option[Instant] = None,
+                                                 numPartitions: Option[NumPartitions] = None,
+                                               ): TopicMetadataV2Request =
+    TopicMetadataV2Request(
+      Schemas(keySchema, valueSchema),
+      StreamTypeV2.Event,
+      deprecated = deprecated,
+      deprecatedDate,
+      Public,
+      NonEmptyList.of(Email.create(email).get),
+      createdDate,
+      List.empty,
+      None,
+      Some("dvs-teamName"),
+      numPartitions,
+      List.empty
+    )
+
+  def getSchema(name: String): Schema =
     SchemaBuilder
       .record(name)
       .fields()


### PR DESCRIPTION
- I’ve added a separate validator (`KeyAndValueSchemaV2Validator`) for data validation
But it should be created inside `CreateTopicProgram`. I didn’t do that because for it we need to refactor all Programs
- I’ve refactored `CreateTopicProgramSpec`. I removed copy-paste code (the class reduced by ~700 lines) and reworked tests with errors - now all tests check for certain errors (before tests checked that the test was falling and that's it)

Ticket: [https://pluralsight.atlassian.net/browse/ADAPT-825](ADAPT-825)

**All tests in Postman passed.**
**<img width="410" alt="Screenshot 2022-01-18 at 19 44 42" src="https://user-images.githubusercontent.com/93545362/149990633-3a01b57b-1ee9-4e73-91a5-4bc8053b859c.png">**