### PR TITLE
ADAPT-1794: Replace cutoff-dates with enum based additional validations on new topics

### DIFF
--- a/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
+++ b/ingest/src/main/scala/hydra.ingest/app/AppConfig.scala
@@ -70,9 +70,7 @@ object AppConfig {
       bootstrapServers: String,
       defaultNumPartions: Int,
       defaultReplicationFactor: Short,
-      defaultMinInsyncReplicas: Short,
-      timestampValidationCutoffDate: Instant,
-      defaultLoopHoleCutoffDate: Instant
+      defaultMinInsyncReplicas: Short
   )
 
   private[app] implicit val dateStringToInstantDecoder: ConfigDecoder[String, Instant] =
@@ -94,13 +92,7 @@ object AppConfig {
       env("HYDRA_KAFKA_PRODUCER_BOOTSTRAP_SERVERS").as[String],
       env("HYDRA_DEFAULT_PARTIONS").as[Int].default(10),
       env("HYDRA_REPLICATION_FACTOR").as[Short].default(3),
-      env("HYDRA_MIN_INSYNC_REPLICAS").as[Short].default(2),
-      env("TIMESTAMP_VALIDATION_CUTOFF_DATE_IN_YYYYMMDD")
-        .as[Instant]
-        .default(Instant.parse("2023-08-31T00:00:00Z")),
-      env("DEFAULT_LOOPHOLE_CUTOFF_DATE_IN_YYYYMMDD")
-        .as[Instant]
-        .default(Instant.parse("2023-08-31T00:00:00Z"))
+      env("HYDRA_MIN_INSYNC_REPLICAS").as[Short].default(2)
       ).parMapN(CreateTopicConfig)
 
   private implicit val subjectConfigDecoder: ConfigDecoder[String, Subject] =

--- a/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Bootstrap.scala
@@ -65,7 +65,8 @@ final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
             Some("Data-Platform"),
             None,
             List.empty,
-            None
+            None,
+            additionalValidations = None
           ),
           TopicDetails(cfg.numPartitions, cfg.replicationFactor, cfg.minInsyncReplicas, Map("cleanup.policy" -> "compact"))
         )
@@ -93,7 +94,8 @@ final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
           Some("Data-Platform"),
           None,
           List.empty,
-          None
+          None,
+          additionalValidations = None
         ),
         TopicDetails(
           dvsConsumersTopicConfig.numPartitions,
@@ -124,7 +126,8 @@ final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
           Some("Data-Platform"),
           None,
           List.empty,
-          None
+          None,
+          additionalValidations = None
         ),
         TopicDetails(
           cooTopicConfig.numPartitions,
@@ -152,7 +155,8 @@ final class Bootstrap[F[_]: MonadError[*[_], Throwable]] private (
         Some("Data-Platform"),
         None,
         List.empty,
-        None
+        None,
+        additionalValidations = None
       ),
       TopicDetails(cfg.numPartitions, cfg.replicationFactor, cfg.minInsyncReplicas, Map("cleanup.policy" -> "compact")))
   }

--- a/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
+++ b/ingest/src/main/scala/hydra.ingest/modules/Programs.scala
@@ -29,8 +29,7 @@ final class Programs[F[_]: Logger: Sync: Timer: Mode: Concurrent] private(
     algebras.kafkaClient,
     retryPolicy,
     cfg.metadataTopicsConfig.topicNameV2,
-    algebras.metadata,
-    cfg.createTopicConfig.defaultLoopHoleCutoffDate
+    algebras.metadata
   )
 
   val ingestionFlow: IngestionFlow[F] = new IngestionFlow[F](
@@ -45,8 +44,7 @@ final class Programs[F[_]: Logger: Sync: Timer: Mode: Concurrent] private(
     algebras.schemaRegistry,
     algebras.kafkaClient,
     cfg.createTopicConfig.schemaRegistryConfig.fullUrl,
-    algebras.metadata,
-    cfg.createTopicConfig.timestampValidationCutoffDate
+    algebras.metadata
   )
 
   val topicDeletion: TopicDeletionProgram[F] = new TopicDeletionProgram[F](

--- a/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/http/IngestionEndpointSpec.scala
@@ -57,12 +57,12 @@ final class IngestionEndpointSpec
     } yield sr).unsafeRunSync
     val metadata = (for {
       m <- TestMetadataAlgebra()
-      _ <- TopicUtils.updateTopicMetadata(List(testSubject.value), m, Instant.now)
+      _ <- TopicUtils.updateTopicMetadata(List(testSubject.value), m)
     } yield m).unsafeRunSync
     new IngestionEndpoint(
       new IngestionFlow[IO](schemaReg, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal"),
       new IngestionFlowV2[IO](SchemaRegistry.test[IO].unsafeRunSync, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistryUrl.notreal",
-        metadata, timestampValidationCutoffDate), noAuth
+        metadata), noAuth
     ).route
   }
 
@@ -104,11 +104,11 @@ final class IngestionEndpointSpec
       _ <- schemaRegistry.registerSchema("dvs.blah.composit-key", compositeKey)
       _ <- schemaRegistry.registerSchema("dvs.blah.composit-value", simpleSchema)
       m <- TestMetadataAlgebra()
-      _ <- TopicUtils.updateTopicMetadata(List(testSubject.value), m, Instant.now)
+      _ <- TopicUtils.updateTopicMetadata(List(testSubject.value), m)
     } yield {
       new IngestionEndpoint(
         new IngestionFlow[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal"),
-        new IngestionFlowV2[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal", m, timestampValidationCutoffDate),
+        new IngestionFlowV2[IO](schemaRegistry, KafkaClientAlgebra.test[IO].unsafeRunSync, "https://schemaregistry.notreal", m),
         noAuth
       ).route
     }).unsafeRunSync()

--- a/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/modules/BootstrapSpec.scala
@@ -62,8 +62,7 @@ class BootstrapSpec extends AnyWordSpecLike with Matchers with NotificationsTest
         kafkaClient,
         retry,
         metadataSubjectV2,
-        metadata,
-        Instant.parse("2023-07-05T00:00:00Z")
+        metadata
       )
       boot <- Bootstrap.make[IO](c, metadataConfig, consumersTopicConfig, consumerOffsetsOffsetsTopicConfig, kafkaAdmin, tagsTopicConfig)
       _ <- boot.bootstrapAll

--- a/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
+++ b/ingest/src/test/scala/hydra/ingest/programs/TopicDeletionProgramSpec.scala
@@ -145,7 +145,8 @@ class TopicDeletionProgramSpec extends AnyFlatSpec with Matchers {
       Some("dvs-teamName"),
       None,
       List.empty,
-      Some("notificationUrl")
+      Some("notificationUrl"),
+      additionalValidations = None
     )
 
   private def buildSchema(topic: String, upgrade: Boolean): Schema = {

--- a/ingest/src/test/scala/hydra/ingest/utils/TopicUtils.scala
+++ b/ingest/src/test/scala/hydra/ingest/utils/TopicUtils.scala
@@ -3,20 +3,18 @@ package hydra.ingest.utils
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
-import hydra.avro.registry.SchemaRegistry
-import hydra.avro.registry.SchemaRegistry.SchemaId
 import hydra.kafka.algebras.MetadataAlgebra.TopicMetadataContainer
 import hydra.kafka.algebras.TestMetadataAlgebra
 import hydra.kafka.model.ContactMethod.Email
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import hydra.kafka.model._
-import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.SchemaBuilder
 
 import java.time.Instant
 
 object TopicUtils {
 
-  def updateTopicMetadata(topics: List[String], metadataAlgebra: TestMetadataAlgebra[IO], createdDate: Instant): IO[List[Unit]] = {
+  def updateTopicMetadata(topics: List[String], metadataAlgebra: TestMetadataAlgebra[IO]): IO[List[Unit]] = {
     topics.traverse(topic => {
       val keySchema = SchemaBuilder.record(topic + "Key").fields.requiredInt("test").endRecord()
       val valueSchema = SchemaBuilder.record(topic + "Value").fields.requiredInt("test").endRecord()
@@ -28,13 +26,14 @@ object TopicUtils {
         deprecatedDate = None,
         Public,
         NonEmptyList.of(Email.create("test@test.com").get),
-        createdDate,
+        Instant.now(),
         List.empty,
         None,
         Some("dvs-teamName"),
         None,
         List.empty,
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
       )
       val topicMetadataContainer = TopicMetadataContainer(
         topicMetadataKey,

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/AdditionalValidation.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/AdditionalValidation.scala
@@ -1,0 +1,46 @@
+package hydra.kafka.model
+
+import enumeratum.{Enum, EnumEntry}
+import hydra.kafka.algebras.MetadataAlgebra.TopicMetadataContainer
+
+import scala.collection.immutable
+
+sealed trait AdditionalValidation extends EnumEntry
+
+sealed trait SchemaAdditionalValidation extends AdditionalValidation
+
+object SchemaAdditionalValidation extends Enum[SchemaAdditionalValidation] {
+
+  case object defaultInRequiredField extends SchemaAdditionalValidation
+  case object timestampMillis extends SchemaAdditionalValidation
+
+  override val values: immutable.IndexedSeq[SchemaAdditionalValidation] = findValues
+}
+
+object AdditionalValidation {
+  lazy val allValidations: Option[List[AdditionalValidation]] =
+    Some(SchemaAdditionalValidation.values.toList)
+
+  /**
+   * An OLD topic will have its metadata populated.
+   * Therefore, additionalValidations=None will be picked from the metadata.
+   * And no new additionalValidations will be applied on older topics.
+   *
+   * A NEW topic will not have a metadata object.
+   * Therefore, all existing additionalValidations will be assigned.
+   * Thus, additionalValidations on corresponding fields will be applied.
+   *
+   * Corner case: After this feature has been on STAGE/PROD for sometime and some new additionalValidations are required.
+   * We need not worry about old topics as the value of additionalValidations will remain the same since the topic creation.
+   * New additionalValidations should be applied only on new topics.
+   * Therefore, assigning all the values under AdditionalValidation enum is reasonable.
+   *
+   * @param metadata a metadata object of current topic
+   * @return value of additionalValidations if the topic is already existing(OLD topic) otherwise all enum values under AdditionalValidation(NEW topic)
+   */
+  def validations(metadata: Option[TopicMetadataContainer]): Option[List[AdditionalValidation]] =
+    metadata.map(_.value.additionalValidations).getOrElse(AdditionalValidation.allValidations)
+
+  def isPresent(metadata: Option[TopicMetadataContainer], additionalValidation: AdditionalValidation): Boolean =
+    validations(metadata).exists(_.contains(additionalValidation))
+}

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadata.scala
@@ -151,7 +151,8 @@ final case class TopicMetadataV2ValueOptionalTagList(
                                          notes: Option[String],
                                          teamName: Option[String],
                                          tags: Option[List[String]],
-                                         notificationUrl: Option[String]
+                                         notificationUrl: Option[String],
+                                         additionalValidations: Option[List[AdditionalValidation]]
                                        ) {
   def toTopicMetadataV2Value: TopicMetadataV2Value = {
     TopicMetadataV2Value(
@@ -165,7 +166,8 @@ final case class TopicMetadataV2ValueOptionalTagList(
       notes,
       teamName,
       tags.getOrElse(List.empty),
-      notificationUrl
+      notificationUrl,
+      additionalValidations
     )
   }
 }
@@ -182,7 +184,8 @@ final case class TopicMetadataV2Value(
     notes: Option[String],
     teamName: Option[String],
     tags: List[String],
-    notificationUrl: Option[String]
+    notificationUrl: Option[String],
+    additionalValidations: Option[List[AdditionalValidation]]
 ) {
   def toTopicMetadataV2ValueOptionalTagList: TopicMetadataV2ValueOptionalTagList = {
     TopicMetadataV2ValueOptionalTagList(
@@ -196,7 +199,8 @@ final case class TopicMetadataV2Value(
       notes,
       teamName,
       tags.some,
-      notificationUrl
+      notificationUrl,
+      additionalValidations
     )
   }
 }
@@ -258,6 +262,22 @@ object TopicMetadataV2ValueOptionalTagList {
   private implicit val contactMethodCodec: Codec[ContactMethod] =
     Codec.derive[ContactMethod]
 
+  private implicit val additionalValidationCodec: Codec[AdditionalValidation] = Codec.deriveEnum[AdditionalValidation](
+    symbols = List(
+      SchemaAdditionalValidation.defaultInRequiredField.entryName,
+      SchemaAdditionalValidation.timestampMillis.entryName
+    ),
+    encode = {
+      case SchemaAdditionalValidation.defaultInRequiredField => SchemaAdditionalValidation.defaultInRequiredField.entryName
+      case SchemaAdditionalValidation.timestampMillis        => SchemaAdditionalValidation.timestampMillis.entryName
+    },
+    decode = {
+      case "defaultInRequiredField" => Right(SchemaAdditionalValidation.defaultInRequiredField)
+      case "timestampMillis"        => Right(SchemaAdditionalValidation.timestampMillis)
+      case other                    => Left(AvroError(s"$other is not a ${AdditionalValidation.toString}"))
+    }
+  )
+
   implicit val codec: Codec[TopicMetadataV2ValueOptionalTagList] =
   Codec.record[TopicMetadataV2ValueOptionalTagList](
     name = "TopicMetadataV2Value",
@@ -274,7 +294,8 @@ object TopicMetadataV2ValueOptionalTagList {
         field("notes", _.notes, default = Some(None)),
         field("teamName", _.teamName, default = Some(None)),
         field("tags", _.tags, default = Some(None)),
-        field("notificationUrl", _.notificationUrl, default = Some(None))
+        field("notificationUrl", _.notificationUrl, default = Some(None)),
+        field("additionalValidations", _.additionalValidations, default = Some(None))
         ).mapN(TopicMetadataV2ValueOptionalTagList.apply)
   }
 }

--- a/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadataV2Transport.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/model/TopicMetadataV2Transport.scala
@@ -86,7 +86,8 @@ final case class TopicMetadataV2Request(
                                          teamName: Option[String],
                                          numPartitions: Option[TopicMetadataV2Request.NumPartitions],
                                          tags: List[String],
-                                         notificationUrl: Option[String]
+                                         notificationUrl: Option[String],
+                                         additionalValidations: Option[List[AdditionalValidation]]
                                        ) {
 
   def toValue: TopicMetadataV2Value = {
@@ -101,7 +102,8 @@ final case class TopicMetadataV2Request(
       notes,
       teamName,
       tags,
-      notificationUrl
+      notificationUrl,
+      additionalValidations
     )
   }
 }
@@ -146,7 +148,8 @@ object TopicMetadataV2Request {
       mor.teamName,
       mor.numPartitions,
       mor.tags,
-      mor.notificationUrl
+      mor.notificationUrl,
+      mor.additionalValidations
     )
   }
 }
@@ -202,7 +205,8 @@ final case class MetadataOnlyRequest(streamType: StreamTypeV2,
                                      teamName: Option[String],
                                      numPartitions: Option[TopicMetadataV2Request.NumPartitions],
                                      tags: List[String],
-                                     notificationUrl: Option[String]) {
+                                     notificationUrl: Option[String],
+                                     additionalValidations: Option[List[AdditionalValidation]]) {
 }
 
 

--- a/ingestors/kafka/src/main/scala/hydra/kafka/programs/RequiredFieldStructures.scala
+++ b/ingestors/kafka/src/main/scala/hydra/kafka/programs/RequiredFieldStructures.scala
@@ -20,8 +20,8 @@ object RequiredFieldStructures {
   private def validateTimestampType(field: Schema.Field) =
     field.schema.getLogicalType == LogicalTypes.timestampMillis && field.schema.getType == Type.LONG
 
-  def defaultFieldOfRequiredFieldValidator(schema: Schema, field: String, isCreatedPostCutoffDate: Boolean): Boolean = {
+  def defaultFieldOfRequiredFieldValidator(schema: Schema, field: String, validateDefaultInRequiredField: Boolean): Boolean = {
     val requiredField = schema.getFields.asScala.toList.find(_.name == field)
-    if (isCreatedPostCutoffDate && requiredField.nonEmpty) requiredField.exists(!_.hasDefaultValue) else true
+    if (validateDefaultInRequiredField && requiredField.nonEmpty) requiredField.exists(!_.hasDefaultValue) else true
   }
 }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/algebras/MetadataAlgebraSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/algebras/MetadataAlgebraSpec.scala
@@ -125,7 +125,8 @@ class MetadataAlgebraSpec extends AnyWordSpecLike with Matchers with Notificatio
         None,
         Some("dvs-teamName"),
         List.empty,
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
         )
     (TopicMetadataV2.encode[IO](key, if (nullValue) None else Some(value), None), key, value)
   }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/BootstrapEndpointV2Spec.scala
@@ -63,8 +63,7 @@ final class BootstrapEndpointV2Spec
         kc,
         retryPolicy,
         Subject.createValidated("dvs.hello-world").get,
-        m,
-        Instant.parse("2023-07-05T00:00:00Z")
+        m
       ),
       TopicDetails(1, 1, 1),
       t,
@@ -135,7 +134,8 @@ final class BootstrapEndpointV2Spec
       Some("dvs-teamName"),
       None,
       List.empty,
-      Some("notificationUrl")
+      Some("notificationUrl"),
+      additionalValidations = None
     ).toJson.compactPrint
 
     val validRequestWithoutDVSTag = TopicMetadataV2Request(
@@ -151,7 +151,8 @@ final class BootstrapEndpointV2Spec
       Some("dvs-teamName"),
       None,
       List.empty,
-      Some("notificationUrl")
+      Some("notificationUrl"),
+      additionalValidations = None
     ).toJson.compactPrint
 
     val validRequestWithDVSTag = TopicMetadataV2Request(
@@ -167,7 +168,8 @@ final class BootstrapEndpointV2Spec
       Some("dvs-teamName"),
       None,
       List("DVS"),
-      Some("notificationUrl")
+      Some("notificationUrl"),
+      additionalValidations = None
     ).toJson.compactPrint
 
     "accept a valid request without a DVS tag" in {
@@ -237,7 +239,8 @@ final class BootstrapEndpointV2Spec
         None,
         None,
         List.empty,
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
       ).toJson.compactPrint
       testCreateTopicProgram
         .map { bootstrapEndpoint =>
@@ -310,7 +313,8 @@ final class BootstrapEndpointV2Spec
         Some("dvs-teamName"),
         None,
         List("DVS"),
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
       ).toJson.compactPrint
 
 
@@ -338,7 +342,8 @@ final class BootstrapEndpointV2Spec
         Some("dvs-teamName"),
         None,
         List("Source: NotValid"),
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
       ).toJson.compactPrint
 
       implicit val notificationSenderMock: InternalNotificationSender[IO] = getInternalNotificationSenderMock[IO]

--- a/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/TopicMetadataEndpointSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/endpoints/TopicMetadataEndpointSpec.scala
@@ -99,8 +99,7 @@ class TopicMetadataEndpointSpec
         kc,
         retryPolicy,
         Subject.createValidated("dvs.hello-world").get,
-        m,
-        Instant.parse("2023-07-05T00:00:00Z")
+        m
       )
   }
 

--- a/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/model/TopicMetadataSpec.scala
@@ -55,6 +55,7 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
       None,
       Some("dvs-teamName"),
       List.empty,
+      None,
       None
     )
 
@@ -84,7 +85,8 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
          |"parentSubjects": [],
          |"notes": null,
          |"notificationUrl": null,
-         |"tags": null
+         |"tags": null,
+         |"additionalValidations": null
          |}""".stripMargin
 
     val decoder = DecoderFactory.get().jsonDecoder(valueSchema, json)
@@ -108,7 +110,8 @@ final class TopicMetadataSpec extends AnyFlatSpecLike with Matchers {
       None,
       Some("dvs-teamName"),
       List.empty,
-      Some("notificationUrl")
+      Some("notificationUrl"),
+      None
     )
 
     val (encodedKey, encodedValue, headers) =

--- a/ingestors/kafka/src/test/scala/hydra/kafka/serializers/TopicMetadataV2ParserSpec.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/serializers/TopicMetadataV2ParserSpec.scala
@@ -358,7 +358,8 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
           Some(teamName),
           None,
           List.empty,
-          None
+          None,
+          additionalValidations = None
         )
     }
 
@@ -402,7 +403,8 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
           Some(teamName),
           None,
           List.empty,
-          None
+          None,
+          additionalValidations = None
         )
     }
 
@@ -596,7 +598,8 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
         teamName = Some(teamName),
         numPartitions = np,
         tags = tags,
-        notificationUrl = notificationUrl
+        notificationUrl = notificationUrl,
+        additionalValidations = None
       )
       TopicMetadataV2Format.write(topicMetadataV2) shouldBe
         createJsValueOfTopicMetadataV2Request(
@@ -627,13 +630,13 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       val tmc = TopicMetadataContainer(TopicMetadataV2Key(subject),
         TopicMetadataV2Value(StreamTypeV2.Entity, false, None, Public,
           NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get),
-          Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None),
+          Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None, None),
         Some(new SchemaFormat(isKey = true).read(validAvroSchema)),
         Some(new SchemaFormat(isKey = false).read(validAvroSchema)))
       val response = TopicMetadataV2Response.fromTopicMetadataContainer(tmc)
       val request = TopicMetadataV2Request.apply(Schemas(tmc.keySchema.get, tmc.valueSchema.get),tmc.value.streamType,
         tmc.value.deprecated,tmc.value.deprecatedDate,tmc.value.dataClassification,tmc.value.contact,
-        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes, teamName = tmc.value.teamName, None, List.empty, None)
+        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes, teamName = tmc.value.teamName, None, List.empty, None, None)
 
       TopicMetadataV2Format.write(request).compactPrint shouldBe
         TopicMetadataResponseV2Format.write(response).compactPrint.replace(",\"subject\":\"dvs.valid\"", "")
@@ -673,12 +676,12 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       val before = Instant.now
       val tmc = TopicMetadataContainer(TopicMetadataV2Key(subject),
         TopicMetadataV2Value(StreamTypeV2.Entity, true, None,
-          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None),
+          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None, None),
         Some(new SchemaFormat(isKey = true).read(validAvroSchema)),
         Some(new SchemaFormat(isKey = false).read(validAvroSchema)))
       val request = TopicMetadataV2Request.apply(Schemas(tmc.keySchema.get, tmc.valueSchema.get),tmc.value.streamType,
         tmc.value.deprecated,tmc.value.deprecatedDate,tmc.value.dataClassification,tmc.value.contact,
-        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes,tmc.value.teamName, None, List.empty, None)
+        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes,tmc.value.teamName, None, List.empty, None, None)
       val firstDeprecatedDate = TopicMetadataV2Format.read(request.toJson).deprecatedDate.getOrElse(None)
       firstDeprecatedDate shouldBe None
     }
@@ -688,12 +691,12 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       val now = Instant.now
       val tmc = TopicMetadataContainer(TopicMetadataV2Key(subject),
         TopicMetadataV2Value(StreamTypeV2.Entity, true, Some(now),
-          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None),
+          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None, None),
         Some(new SchemaFormat(isKey = true).read(validAvroSchema)),
         Some(new SchemaFormat(isKey = false).read(validAvroSchema)))
       val request = TopicMetadataV2Request.apply(Schemas(tmc.keySchema.get, tmc.valueSchema.get),tmc.value.streamType,
         tmc.value.deprecated,tmc.value.deprecatedDate,tmc.value.dataClassification,tmc.value.contact,tmc.value.createdDate,
-        tmc.value.parentSubjects,tmc.value.notes,tmc.value.teamName, None, List.empty, None)
+        tmc.value.parentSubjects,tmc.value.notes,tmc.value.teamName, None, List.empty, None, None)
       val firstDeprecatedDate = TopicMetadataV2Format.read(request.toJson).deprecatedDate.get
       val now2 = Instant.now
       now2.isAfter(firstDeprecatedDate) shouldBe true
@@ -704,12 +707,12 @@ class TopicMetadataV2ParserSpec extends AnyWordSpecLike with Matchers {
       val subject = Subject.createValidated("dvs.valid").get
       val tmc = TopicMetadataContainer(TopicMetadataV2Key(subject),
         TopicMetadataV2Value(StreamTypeV2.Entity, false, None,
-          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None),
+          Public, NonEmptyList.one(ContactMethod.create("blah@pluralsight.com").get), Instant.now(), List.empty, None, Some("dvs-teamName"), List.empty, None, None),
         Some(new SchemaFormat(isKey = true).read(validAvroSchema)),
         Some(new SchemaFormat(isKey = false).read(validAvroSchema)))
       val request = TopicMetadataV2Request.apply(Schemas(tmc.keySchema.get, tmc.valueSchema.get),tmc.value.streamType,
         tmc.value.deprecated,tmc.value.deprecatedDate,tmc.value.dataClassification,tmc.value.contact,
-        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes, tmc.value.teamName, None, List.empty, None)
+        tmc.value.createdDate,tmc.value.parentSubjects,tmc.value.notes, tmc.value.teamName, None, List.empty, None, None)
       val firstDeprecatedDate = TopicMetadataV2Format.read(request.toJson).deprecatedDate.getOrElse(None)
       firstDeprecatedDate shouldBe None
     }

--- a/ingestors/kafka/src/test/scala/hydra/kafka/utils/TopicUtils.scala
+++ b/ingestors/kafka/src/test/scala/hydra/kafka/utils/TopicUtils.scala
@@ -3,20 +3,18 @@ package hydra.kafka.utils
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
-import hydra.avro.registry.SchemaRegistry
-import hydra.avro.registry.SchemaRegistry.SchemaId
 import hydra.kafka.algebras.MetadataAlgebra.TopicMetadataContainer
 import hydra.kafka.algebras.TestMetadataAlgebra
 import hydra.kafka.model.ContactMethod.Email
 import hydra.kafka.model.TopicMetadataV2Request.Subject
 import hydra.kafka.model._
-import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.SchemaBuilder
 
 import java.time.Instant
 
 object TopicUtils {
 
-  def updateTopicMetadata(topics: List[String], metadataAlgebra: TestMetadataAlgebra[IO], createdDate: Instant): IO[List[Unit]] = {
+  def updateTopicMetadata(topics: List[String], metadataAlgebra: TestMetadataAlgebra[IO]): IO[List[Unit]] = {
     topics.traverse(topic => {
       val keySchema = SchemaBuilder.record(topic + "Key").fields.requiredInt("test").endRecord()
       val valueSchema = SchemaBuilder.record(topic + "Value").fields.requiredInt("test").endRecord()
@@ -28,13 +26,14 @@ object TopicUtils {
         deprecatedDate = None,
         Public,
         NonEmptyList.of(Email.create("test@test.com").get),
-        createdDate,
+        Instant.now(),
         List.empty,
         None,
         Some("dvs-teamName"),
         None,
         List.empty,
-        Some("notificationUrl")
+        Some("notificationUrl"),
+        additionalValidations = None
       )
       val topicMetadataContainer = TopicMetadataContainer(
         topicMetadataKey,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val scalaTestEmbeddedRedisVersion = "0.4.0"
   val scalaChillBijectionVersion = "0.10.0"
   val awsSdkVersion = "2.17.192"
+  val enumeratumVersion = "1.7.2"
 
   object Compile {
 
@@ -152,6 +153,7 @@ object Dependencies {
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
     )
 
+    val enumeratum = "com.beachape" %% "enumeratum" % enumeratumVersion
   }
 
   // oneOf test, it, main
@@ -200,7 +202,7 @@ object Dependencies {
   val integrationDeps: Seq[ModuleID] = testContainers ++ TestLibraries.getTestLibraries(module = "it")
 
   val baseDeps: Seq[ModuleID] =
-    akka ++ Seq(avro, ciris, refined) ++ cats ++ logging ++ joda ++ testDeps ++ kafkaClients ++ awsMskIamAuth
+    akka ++ Seq(avro, ciris, refined, enumeratum) ++ cats ++ logging ++ joda ++ testDeps ++ kafkaClients ++ awsMskIamAuth
 
   val avroDeps: Seq[ModuleID] =
     baseDeps ++ confluent ++ jackson ++ guavacache ++ catsEffect ++ redisCache


### PR DESCRIPTION
To fix default loophole and timestamp-mills validations on new topics we had introduced cutoff-date. This PR gets rid of those in favour of enum based additional validations stored in metadata.